### PR TITLE
Offer an exit code, but don't actually exit

### DIFF
--- a/bin/kafo-configure
+++ b/bin/kafo-configure
@@ -5,4 +5,4 @@
 
 $LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'kafo'))
 require 'kafo_configure'
-KafoConfigure.run
+exit KafoConfigure.run.exit_code

--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -25,7 +25,7 @@ class Configuration
       @data        = YAML.load_file(@answer_file)
     rescue Errno::ENOENT => e
       puts "No answers file at #{@answer_file} found, can not continue"
-      exit(23)
+      exit(:no_answer_file)
     end
 
     @config_dir  = File.dirname(@config_file)
@@ -66,7 +66,7 @@ class Configuration
       @logger.debug `#{command}`
       unless $?.exitstatus == 0
         @logger.error "Could not get default values, cannot continue"
-        exit(25)
+        exit(:default_error)
       end
       @logger.info "... finished"
       YAML.load_file(File.join(@config_dir, 'default_values.yaml'))

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -43,7 +43,7 @@ class PuppetModule
   rescue ConfigurationException => e
     puts "Unable to continue because of:"
     puts e.message
-    exit(22)
+    KafoConfigure.exit(:manifest_error)
   end
 
   def validations(param = nil)


### PR DESCRIPTION
It's useful when something additional is needed to be done after the puppet
run is finished.

Also, the exit code numbers are translated from symbols in the code for better
readability.
