### PR TITLE
Fixes #3078 - system checks fix for Ruby 1.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,7 @@ right version you can write a simple script and put it into checks directory.
 All files found there will be ran and if any has non-zero exit code, kafo
 wont execute puppet.
 
-Everything on STDOUT is logged in debug level, everything on STDERR is logged
-in error level.
+Everything on STDOUT and STDERR is logged in error level.
 
 Example shell script which checks java version
 

--- a/lib/kafo/system_checker.rb
+++ b/lib/kafo/system_checker.rb
@@ -1,6 +1,4 @@
 # encoding: UTF-8
-# we require separate STDERR
-require 'open3'
 
 class SystemChecker
   def self.check
@@ -18,13 +16,9 @@ class SystemChecker
   def check
     @checkers.map! do |checker|
       logger.debug "Executing checker: #{checker}"
-      Open3.popen3(checker) { |stdin, stdout, stderr, wait_thr|
-        stdout = stdout.read
-        stderr = stderr.read
-        logger.debug stdout unless stdout.empty?
-        logger.error stderr unless stderr.empty?
-        wait_thr.value.success?
-      }
+      stdout = `#{checker}`
+      logger.error stdout unless stdout.empty?
+      $?.exitstatus == 0
     end
 
     @checkers.all?


### PR DESCRIPTION
System checker does not separate STDERR from STDOUT anymore
