### PR TITLE
Adding detailed-exitcodes option

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -179,6 +179,7 @@ class KafoConfigure < Clamp::Command
     self.class.app_option ['-v', '--verbose'], :flag, 'Display log on STDOUT instead of progressbar'
     self.class.app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
                           :default => 'info'
+    self.class.app_option ['-x', '--detailed-exitcodes'], :flag, 'Pass detailed-exitcode option to Puppet and return that?', :default => false
   end
 
   def set_options
@@ -241,9 +242,9 @@ class KafoConfigure < Clamp::Command
         '--debug',
         '--color=false',
         '--show_diff',
-        '--detailed-exitcodes',
     ]
     options.push '--noop' if noop?
+    options.push '--detailed-exitcodes' if detailed_exitcodes?
     begin
       command = PuppetCommand.new('include kafo_configure', options).command
       PTY.spawn(command) do |stdin, stdout, pid|


### PR DESCRIPTION
Kafo and foreman-installer currently exit with error codes same as puppet
which is okay, but we call puppet with --detailed-exitcodes. This is
unexpected, it would be nicer to have the very same option (I also made -x
as short option for those who plan to use this regularly) in the
kafo/foreman-installer as well.

WARNING: This changes behavior of exit codes and we need to patch
foreman-installer and node-installer first.

I would like to get this before 1.3 release, if anyone can help me with
foreman-installer part, I would appreciated.
