### PR TITLE
Remove Fedora 18 koji target

### DIFF
--- a/rel-eng/releasers.conf
+++ b/rel-eng/releasers.conf
@@ -1,3 +1,3 @@
 [koji]
 releaser = tito.release.KojiReleaser
-autobuild_tags = foreman-nightly-nonscl-rhel6 foreman-nightly-fedora18 foreman-nightly-fedora19
+autobuild_tags = foreman-nightly-nonscl-rhel6 foreman-nightly-fedora19

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -7,9 +7,6 @@ changelog_format = %s (%ae)
 [foreman-nightly-nonscl-rhel6]
 disttag = .el6
 
-[foreman-nightly-fedora18]
-disttag = .fc18
-
 [foreman-nightly-fedora19]
 disttag = .fc19
 


### PR DESCRIPTION
The nightly F18 target was removed a couple of days ago, which caused a tito error, so Fedora 19 didn't get built (now fixed).
