### PR TITLE
Adding --trace puppet option as default

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -292,6 +292,7 @@ module Kafo
       options     = [
           '--verbose',
           '--debug',
+          '--trace',
           '--color=false',
           '--show_diff',
           '--detailed-exitcodes',


### PR DESCRIPTION
When I have bugs reported on Smart Proxy provider, I usually need to add this
option to see backtrace from puppet provider. It looks like it does not hurt at
all to Kafo but it provides extra log messages in the INFO level when there is
an exception.

Therefore I vote for adding this as default, I hope I am not missing anything
here. Example output:

```
[DEBUG 2013-12-12 10:32:30 verbose]  Service[foreman-proxy](provider=redhat): Executing '/sbin/service foreman-proxy status'
[DEBUG 2013-12-12 10:32:30 verbose]  Puppet::Type::Service::ProviderRedhat: Executing '/sbin/chkconfig foreman-proxy'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:19:in `[]'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:19:in `proxy'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/gems/1.8/gems/oauth-0.4.7/lib/oauth/signature/hmac/base.rb:11:in `find'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:19:in `each'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:19:in `find'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:19:in `proxy'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:23:in `id'
[ INFO 2013-12-12 10:32:30 verbose] /usr/share/foreman-installer/modules/foreman/lib/puppet/provider/foreman_smartproxy/rest.rb:27:in `exists?'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/property/ensure.rb:68:in `retrieve'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/type.rb:710:in `retrieve'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/type.rb:728:in `retrieve_resource'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction/resource_harness.rb:32:in `perform_changes'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction/resource_harness.rb:133:in `evaluate'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction.rb:49:in `apply'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction.rb:84:in `eval_resource'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction.rb:104:in `evaluate'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/util.rb:509:in `thinmark'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/1.8/benchmark.rb:308:in `realtime'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/util.rb:508:in `thinmark'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction.rb:104:in `evaluate'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction.rb:386:in `traverse'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/transaction.rb:99:in `evaluate'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/resource/catalog.rb:141:in `apply'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/configurer.rb:122:in `retrieve_and_apply_catalog'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/util.rb:161:in `benchmark'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/1.8/benchmark.rb:308:in `realtime'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/util.rb:160:in `benchmark'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/configurer.rb:121:in `retrieve_and_apply_catalog'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/configurer.rb:152:in `run'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application/apply.rb:229:in `main'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application/apply.rb:149:in `run_command'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:309:in `run'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:416:in `hook'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:309:in `run'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:407:in `exit_on_fail'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/application.rb:309:in `run'
[ INFO 2013-12-12 10:32:30 verbose] /usr/lib/ruby/site_ruby/1.8/puppet/util/command_line.rb:69:in `execute'
[ INFO 2013-12-12 10:32:30 verbose] /usr/bin/puppet:4
[ERROR 2013-12-12 10:32:30 verbose]  /Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[el.virtual.lan]: Could not evaluate: can't convert String into Integer
[DEBUG 2013-12-12 10:32:30 verbose]  Finishing transaction 69924272729160
[DEBUG 2013-12-12 10:32:30 verbose]  Storing state
[DEBUG 2013-12-12 10:32:30 verbose]  Stored state in 0.02 seconds
[ WARN 2013-12-12 10:32:30 verbose]  Finished catalog run in 3.00 seconds
```
