### PR TITLE
Fix error with nil modules_dir running kafo-export-params

### DIFF
--- a/bin/kafo-export-params
+++ b/bin/kafo-export-params
@@ -25,9 +25,10 @@ module Kafo
     end
 
     def execute
-      c                      = Configuration.new(config, false)
-      KafoConfigure.config   = c
-      KafoConfigure.root_dir = File.expand_path(c.app[:installer_dir])
+      c                         = Configuration.new(config, false)
+      KafoConfigure.config      = c
+      KafoConfigure.root_dir    = File.expand_path(c.app[:installer_dir])
+      KafoConfigure.modules_dir = File.expand_path(c.app[:modules_dir])
 
       exporter = self.class.const_get(format.capitalize).new(c)
       exporter.print_out


### PR DESCRIPTION
http://koji.katello.org/koji/getfile?taskID=73251&name=build.log

<pre>
/usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/lib/kafo/puppet_module.rb:20:in `join': can't convert nil into String (TypeError)
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/lib/kafo/puppet_module.rb:20:in `initialize'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/lib/kafo/configuration.rb:71:in `new'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/lib/kafo/configuration.rb:71:in `modules'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/lib/kafo/configuration.rb:71:in `map'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/lib/kafo/configuration.rb:71:in `modules'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/bin/kafo-export-params:83:in `print_out'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/bin/kafo-export-params:33:in `execute'
    from /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'
    from /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:125:in `run'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.6/bin/kafo-export-params:128
    from /usr/lib/ruby/gems/1.8/bin/kafo-export-params:19:in `load'
    from /usr/lib/ruby/gems/1.8/bin/kafo-export-params:19
</pre>
