### PR TITLE
Fix uninitialized constant during rpmbuild with unknown modules_dir

### DIFF
--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -47,7 +47,7 @@ module Kafo
       @groups = builder.build_param_groups(@params)
 
       self
-    rescue ConfigurationException => e
+    rescue Kafo::ConfigurationException => e
       @logger.error "Unable to continue because of: #{e.message}"
       KafoConfigure.exit(:manifest_error)
     end


### PR DESCRIPTION
http://koji.katello.org/koji/getfile?taskID=73464&name=build.log

<pre>
/usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/lib/kafo/puppet_module.rb:50:in `parse': uninitialized constant Kafo::PuppetModule::ConfigurationException (NameError)
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/lib/kafo/configuration.rb:71:in `modules'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/lib/kafo/configuration.rb:71:in `map'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/lib/kafo/configuration.rb:71:in `modules'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/bin/kafo-export-params:84:in `print_out'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/bin/kafo-export-params:34:in `execute'
    from /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:67:in `run'
    from /usr/lib/ruby/gems/1.8/gems/clamp-0.6.2/lib/clamp/command.rb:125:in `run'
    from /usr/lib/ruby/gems/1.8/gems/kafo-0.3.7/bin/kafo-export-params:129
    from /usr/lib/ruby/gems/1.8/bin/kafo-export-params:19:in `load'
    from /usr/lib/ruby/gems/1.8/bin/kafo-export-params:19
rake aborted!
</pre>


The modules_dir didn't exist, causing an error of some sort and then the error handler hit this bug.  I haven't verified this fix though.
