### PR TITLE
Fix #4402 - remove definition support

### DIFF
--- a/lib/kafo/puppet_module_parser.rb
+++ b/lib/kafo/puppet_module_parser.rb
@@ -38,11 +38,7 @@ module Kafo
         ast_type = ast_objects.last
         @object = ast_type if ast_type.file == file
       end
-      # Find object in list of definitions
-      parser.environment.known_resource_types.definitions.each do |ast_objects|
-        ast_type = ast_objects.last
-        @object = ast_type.last if ast_type.last.file == file
-      end
+
       parser
     end
 

--- a/lib/kafo/version.rb
+++ b/lib/kafo/version.rb
@@ -1,4 +1,4 @@
 # encoding: UTF-8
 module Kafo
-  VERSION = "0.3.15"
+  VERSION = "0.3.16"
 end


### PR DESCRIPTION
Definitions were never supported in the first place. We support only
parametrized classes.
