### PR TITLE
add /usr/local to default config file path

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -356,6 +356,7 @@ module Kafo
     def config_file
       return CONFIG_FILE if defined?(CONFIG_FILE) && File.exists?(CONFIG_FILE)
       return '/etc/kafo/kafo.yaml' if File.exists?('/etc/kafo/kafo.yaml')
+      return '/usr/local/etc/kafo/kafo.yaml' if File.exists?('/usr/local/etc/kafo/kafo.yaml')
       File.join(Dir.pwd, 'config', 'kafo.yaml')
     end
 


### PR DESCRIPTION
On FreeBSD config files are in /usr/local/etc/... It would be nice if this could be applied here, so it doesn't need to be patched on FreeBSD ports.
