### PR TITLE
Fix default value setting

### DIFF
--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -46,7 +46,7 @@ module Kafo
         # we fallback to their own default values
         if defaults.has_key?(default)
           value = defaults[default]
-          self.value = ([:undef, :undefined].include?(value) ? nil : value)
+          self.value = ([:undef, :undefined].include?(value) ? self.default : value)
         else
           self.value = self.default
         end


### PR DESCRIPTION
When we add parameter from hook a we set value nil so default value
would be used but it would also set value_set flag to true. Therefore a
value would be used instead of default value. This fix sets default
value to be the value of such parameter.
