### PR TITLE
Fixed 1 failed test in wizard_test.rb

### DIFF
--- a/test/kafo/wizard_test.rb
+++ b/test/kafo/wizard_test.rb
@@ -83,7 +83,7 @@ module Kafo
           it "displays menu" do
             must_exit_with_code(0) { wizard.send :main_menu }
             must_be_on_stdout(output,
-                              "[✓] Configure puppet",
+                              "Choose an option from the menu... ",
                               'Display current config',
                               'Save and run',
                               'Cancel run without Saving')


### PR DESCRIPTION
Fixes the 1 failure when running tests, which yields the following results:

Finished tests in 0.961535s, 220.4807 tests/s, 400.4012 assertions/s.

  1) Failure:
Kafo::Wizard::menu navigation::#main_menu::list all modules, run installation and cancel options, then cancel#test_0001_displays menu [/vagrant/kafo/test/kafo/wizard_test.rb:85]:
Expected "\nMain Config Menu\n1. [y] Configure puppet\n2. Display current config\n3. Save and run\n4. Cancel run without Saving\nChoose an option from the menu... You must choose one of [1, 2, 3, 4].\n?  " to include "[✓] Configure puppet".

212 tests, 385 assertions, 1 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /vagrant/kafo/coverage. 834 / 1202 LOC (69.38%) covered.
rake aborted!
Command failed with status (1): [ruby -I"lib:lib:test" -I"/home/vagrant/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib" "/home/vagrant/.rvm/gems/ruby-1.9.3-p551/gems/rake-10.4.2/lib/rake/rake_test_loader.rb" "test/kafo/color_scheme_test.rb" "test/kafo/condition_test.rb" "test/kafo/exit_handler_test.rb" "test/kafo/help_builders/advanced_test.rb" "test/kafo/help_builders/basic_test.rb" "test/kafo/hook_context_test.rb" "test/kafo/hooking_test.rb" "test/kafo/logger_test.rb" "test/kafo/param_test.rb" "test/kafo/params/array_test.rb" "test/kafo/params/hash_test.rb" "test/kafo/params/password_test.rb" "test/kafo/puppet_module_test.rb" "test/kafo/validator_test.rb" "test/kafo/wizard_test.rb" ]
/home/vagrant/.rvm/gems/ruby-1.9.3-p551/bin/ruby_executable_hooks:15:in `eval'
/home/vagrant/.rvm/gems/ruby-1.9.3-p551/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
