### PR TITLE
Fixes #10162 - Added scenario support

### DIFF
--- a/bin/kafofy
+++ b/bin/kafofy
@@ -12,25 +12,30 @@ require 'kafo/configuration'
 options = {}
 OptionParser.new do |opts|
   opts.banner = "Usage: kafofy"
-  options[:answer_file] = './config/answers.yaml'
-  opts.on("-a", "--answer_file FILE", "location of the answer file") do |answer_file|
-    options[:answer_file] = answer_file
+  options[:config_dir] = './config/installer-scenarios.d/'
+  opts.on("-c", "--config_dir DIR", "location of the scenarios configuration directory [./config/installer-scenarios.d/]") do |config_dir|
+    options[:config_dir] = config_dir
   end
-  opts.on("-c", "--config_file FILE", "location of the configuration file") do |config_file|
-    options[:config_file] = config_file
+  opts.on("-s", "--scenario SCENARIO", "scenario file name (without extension) [default]") do |scenario|
+    options[:scenario] = scenario
   end
-  opts.on("-n", "--name NAME", "installer name") do |name|
+  opts.on("-a", "--answer_file ANSWERS", "answer file file name (without extension) [default-answers]") do |answer_file|
+    options[:answer_file] = File.join(options[:config_dir], answer_file + '.yaml')
+  end
+  opts.on("-n", "--name NAME", "installer name [kafo-configure]") do |name|
     options[:name] = name
   end
 end.parse!
 
 config = Kafo::Configuration::DEFAULT
-options[:answer_file] ||= config[:answer_file]
+options[:scenario] ||= 'default'
+options[:answer_file] ||= File.join(options[:config_dir],  options[:scenario] + '-answers.yaml')
 options[:name] ||= "kafo-configure"
-options[:config_file] ||= "./config/#{options[:name]}.yaml"
+options[:config_file] ||= File.join(options[:config_dir], options[:scenario] + '.yaml')
 
 # Create directory structure
-%w(bin config modules hooks).each do |dir|
+dirs = %w(bin config modules hooks) << options[:config_dir]
+dirs.each do |dir|
   FileUtils.mkdir_p dir
 end
 
@@ -41,7 +46,7 @@ src = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 end
 
 # Create default config file
-puts "using #{options[:config_file]} as default config file"
+puts "creating #{options[:config_file]} as a default scenario file"
 if !File.exists?(options[:config_file])
   puts "... creating config file #{options[:config_file]}"
   FileUtils.touch options[:config_file]
@@ -49,23 +54,35 @@ if !File.exists?(options[:config_file])
   FileUtils.cp('config/kafo.yaml.example', options[:config_file])
   if options[:answer_file]
     `sed -i 's/^# :answer_file.*$/:answer_file: #{options[:answer_file].gsub('/', '\/')}/' #{options[:config_file]}`
-    `sed -i 's/^# :name.*$/:name: #{options[:name]}/' #{options[:config_file]}`
+    `sed -i 's/^# :name.*$/:name: #{options[:scenario]}/' #{options[:config_file]}`
   end
 end
 
-# Installer script 
+# Installer script
 script_name = "bin/#{options[:name]}"
 puts "... creating #{script_name}"
-content = <<EOS
+if !File.exists?(script_name)
+  content = <<EOS
 #!/usr/bin/env ruby
 require 'rubygems'
-CONFIG_FILE = '#{options[:config_file]}'
 require 'kafo'
-result = Kafo::KafoConfigure.run
-exit result.nil? ? 0 : result.exit_code
+
+# where to find scenarios
+CONFIG_DIR = '#{options[:config_dir]}'
+
+# Run the install
+@result = Kafo::KafoConfigure.run
+
+# handle exit code when help was invoked or installer ended with '2' (success in puppet)
+if @result.nil? || (!@result.config.app[:detailed_exitcodes] && @result.exit_code == 2)
+  exit(0)
+else
+  exit(@result.exit_code)
+end
 EOS
-File.open(script_name, 'w') { |file| file.write(content) }
-FileUtils.chmod 0755, script_name
+  File.open(script_name, 'w') { |file| file.write(content) }
+  FileUtils.chmod 0755, script_name
+end
 
 puts "Your directory was kafofied"
 
@@ -73,3 +90,4 @@ puts "Now you should:"
 puts "  1. upload your puppet modules to modules directory (you can use librarian-puppet project)"
 puts "  2. create default #{options[:answer_file]} or modify #{options[:config_file]} to load another answer file"
 puts "  3. run #{script_name} to install your modules"
+puts "  Note: You can add more scenarios by running kafofy multiple times"

--- a/config/kafo.yaml.example
+++ b/config/kafo.yaml.example
@@ -3,14 +3,17 @@
 # note current configuration is written to kafo.yaml every time kafo is run
 
 ## Installer configuration
-# Your project name
-# :name: Kafo
+# Human readable scenario name
+# :name: default
+# Description of the installer scenario and its purpose
+# :description:
 # Path to answer file, if the file does not exist a $pwd/config/answers.yaml is used as a fallback
 # :answer_file: /etc/kafo/answers.yaml
 # Custom installer path
 # :installer_dir: /usr/share/kafo/
-# Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default
-# :modules_dir: /usr/share/kafo/modules
+# Uncomment if you want to load puppet modules from a specific path, $pwd/modules is used by default,
+# multiple dirs are allowed
+# :module_dirs: /usr/share/kafo/modules
 # Similar as modules_dir but for kafo internal modules, leave nil if you don't need to change it
 # :kafo_modules_dir:
 # Enable colors? If you don't touch this, we'll autodetect terminal capabilities
@@ -43,6 +46,11 @@
 # when you specify your directory, it will be search for $yourdir/$type/*.rb
 # :hook_dirs:
 # - /opt/hooks
+
+## Checks - system checks in these extra directories will be loaded
+# by default $installer_dir/checks is used
+# :check_dirs:
+# - /opt/checks
 
 # custom storage is handy if you use hooks and you must store some configuration
 # which should persist among installer runs. It can be also used for passing

--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   # puppet module parsing
   spec.add_dependency 'kafo_parsers'
+  spec.add_dependency 'kafo_wizards'
   spec.add_dependency 'puppet', '< 4.0.0'
   # better logging
   spec.add_dependency 'logging', '< 3.0.0'

--- a/lib/kafo/exit_handler.rb
+++ b/lib/kafo/exit_handler.rb
@@ -15,7 +15,9 @@ module Kafo
           :manifest_error => 22,
           :no_answer_file => 23,
           :unknown_module => 24,
-          :defaults_error => 25
+          :defaults_error => 25,
+          :unknown_scenario => 26,
+          :scenario_error => 27
       }
     end
 

--- a/lib/kafo/puppet_command.rb
+++ b/lib/kafo/puppet_command.rb
@@ -39,9 +39,9 @@ module Kafo
 
     def modules_path
       [
-          KafoConfigure.modules_dir,
+          KafoConfigure.module_dirs,
           KafoConfigure.kafo_modules_dir,
-      ].join(':')
+      ].flatten.join(':')
     end
   end
 end

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -18,7 +18,13 @@ module Kafo
       @manifest_name     = get_manifest_name
       @class_name        = get_class_name
       @params            = []
-      @manifest_path     = File.join(KafoConfigure.modules_dir, module_manifest_path)
+      if KafoConfigure.module_dirs.count == 1
+        module_dir       = KafoConfigure.module_dirs.first
+      else
+        module_dir         = KafoConfigure.module_dirs.find { |dir| File.exists?(File.join(dir, module_manifest_path)) } ||
+          warn("Manifest #{module_manifest_path} was not found in #{KafoConfigure.module_dirs.join(', ')}")
+      end
+      @manifest_path     = File.join(module_dir, module_manifest_path)
       @parser            = parser
       @validations       = []
       @logger            = KafoConfigure.logger

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -1,0 +1,137 @@
+# encoding: UTF-8
+require 'kafo_wizards'
+
+module Kafo
+  class ScenarioManager
+    attr_reader :config_dir, :last_scenario_link, :previous_scenario
+
+    def initialize(config, last_scenario_link_name='last_scenario.yaml')
+      @config_dir = File.file?(config) ? File.dirname(config) : config
+      @last_scenario_link = File.join(config_dir, last_scenario_link_name)
+      @previous_scenario = File.realpath(last_scenario_link) if File.exists?(last_scenario_link)
+    end
+
+    def available_scenarios
+      # assume that *.yaml file in config_dir that has key :name is scenario definition
+      @available_scenarios ||= Dir.glob(File.join(config_dir, '*.yaml')).reject { |f| f =~ /#{last_scenario_link}$/ }.inject({}) do |scns, scn_file|
+        begin
+          content = YAML.load_file(scn_file)
+          if content.is_a?(Hash) && content.has_key?(:answer_file)
+            # add scenario name for legacy configs
+            content[:name] = File.basename(scn_file, '.yaml') unless content.has_key?(:name)
+            scns[scn_file] = content
+          end
+        rescue Psych::SyntaxError => e
+          warn "Warning: #{e}"
+        end
+        scns
+      end
+    end
+
+    def list_available_scenarios
+      say "Available scenarios"
+      available_scenarios.each do |config_file, content|
+        scenario = File.basename(config_file, '.yaml')
+        say "  #{content[:name]} (use: --scenario #{scenario})"
+        say "        " + content[:description] unless (content[:description].nil? || content[:description].empty?)
+      end
+      say "  No available scenarios found in #{config_dir}" if available_scenarios.empty?
+      KafoConfigure.exit(0)
+    end
+
+
+    def scenario_selection_wizard
+      wizard = KafoWizards.wizard(:cli, 'Select installation scenario',
+        :description => "Please select one of the pre-set installation scenarios. You can customize your installtion later during the installtion.")
+      f = wizard.factory
+      available_scenarios.keys.each do |scn|
+        label = available_scenarios[scn][:name].to_s
+        label += ": #{available_scenarios[scn][:description]}" if available_scenarios[scn][:description]
+        wizard.entries << f.button(scn, :label => label, :default => true)
+      end
+      wizard.entries << f.button(:cancel, :label => 'Cancel Installation', :default => false)
+      wizard
+    end
+
+    def select_scenario_interactively
+      # let the user select if in interactive mode
+      if (ARGV & ['--interactive', '-i']).any?
+        res = scenario_selection_wizard.run
+        if res == :cancel
+          say 'Installation was cancelled by user'
+          KafoConfigure.exit(0)
+        end
+        res
+      end
+    end
+
+    def scenario_changed?(scenario)
+      scenario = File.realpath(scenario) if File.symlink?(scenario)
+      !!previous_scenario && scenario != previous_scenario
+    end
+
+    def configured?
+      !!(defined?(CONFIG_DIR) && CONFIG_DIR)
+    end
+
+    def select_scenario
+      scenario = scenario_from_args || previous_scenario ||
+        (available_scenarios.keys.count == 1 && available_scenarios.keys.first) ||
+        select_scenario_interactively
+      if scenario.nil?
+        fail_now("Scenario was not selected, can not continue. Use --list-scenarios to list available options.", :unknown_scenario)
+      else
+        # check if scenario was changed
+        confirm_scenario_change(scenario) if scenario_changed?(scenario)
+      end
+      KafoConfigure.logger.info "Scenario #{scenario} was selected"
+      scenario
+    end
+
+    def scenario_from_args
+      # try scenario provided in the args via -S or --scenario
+      parsed = ARGV.join(" ").match /(--scenario|-S)(\s+|[=]?)(\S+)/
+      if parsed
+        scenario_file = File.join(config_dir, "#{parsed[3]}.yaml")
+        return scenario_file if File.exists?(scenario_file)
+        fail_now("Scenario (#{scenario_file}) was not found, can not continue", :unknown_scenario)
+      end
+    end
+
+    def confirm_scenario_change(new_scenario)
+      if (ARGV & ['--interactive', '-i']).any?
+        # TODO: show option diff
+        wizard = KafoWizards.wizard(:cli, 'Confirm installation scenario selection',
+          :description => "You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Please confirm that you want to proceed.")
+        wizard.entries << wizard.factory.button(:proceed, :label => 'Proceed with selected installation scenario', :default => false)
+        wizard.entries << wizard.factory.button(:cancel, :label => 'Cancel Installation', :default => true)
+        result = wizard.run
+        if result == :cancel
+          say 'Installation was cancelled by user'
+          KafoConfigure.exit(0)
+        end
+      else
+        if ARGV.include?('--force')
+          message = "You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Use --force to override."
+          fail_now(message,:scenario_error)
+        end
+      end
+    end
+
+    def link_last_scenario(config_file)
+      link_path = last_scenario_link
+      if last_scenario_link
+        File.delete(last_scenario_link) if File.exist?(last_scenario_link)
+        File.symlink(config_file, last_scenario_link)
+      end
+    end
+
+    private
+
+    def fail_now(message, exit_code)
+      say "ERROR: #{message}"
+      KafoConfigure.logger.error message
+      KafoConfigure.exit(exit_code)
+    end
+  end
+end

--- a/lib/kafo/system_checker.rb
+++ b/lib/kafo/system_checker.rb
@@ -3,7 +3,9 @@
 module Kafo
   class SystemChecker
     def self.check
-      new(File.join(KafoConfigure.root_dir, 'checks', '*')).check
+      KafoConfigure.check_dirs.each do |dir|
+        new(File.join(dir, '*')).check
+      end
     end
 
     def initialize(path)

--- a/lib/kafo/validator.rb
+++ b/lib/kafo/validator.rb
@@ -10,9 +10,11 @@ module Kafo
 
     def initialize(params)
       self.class.prepare_functions
-      validate_files = KafoConfigure.modules_dir + '/*/lib/puppet/parser/functions/validate_*.rb'
-      is_function_files = KafoConfigure.modules_dir + '/*/lib/puppet/parser/functions/is_*.rb'
-      definitions = Dir.glob(validate_files) + Dir.glob(is_function_files)
+      definitions = KafoConfigure.module_dirs.map do |dir|
+        validate_files = dir + '/*/lib/puppet/parser/functions/validate_*.rb'
+        is_function_files = dir + '/*/lib/puppet/parser/functions/is_*.rb'
+        Dir.glob(validate_files) + Dir.glob(is_function_files)
+      end.flatten
 
       definitions.each do |file|
         require File.expand_path(file)

--- a/test/kafo/scenario_manager_test.rb
+++ b/test/kafo/scenario_manager_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+module Kafo
+  describe ScenarioManager do
+    let(:manager) { ScenarioManager.new('/path/to/scenarios.d') }
+    let(:manager_with_file) { ScenarioManager.new('/path/to/scenarios.d/foreman.yaml') }
+
+    describe "#config_dir" do
+      specify { manager.config_dir.must_equal '/path/to/scenarios.d' }
+
+      it "supports old configuration" do
+        File.stub(:file?, true) do
+          manager_with_file.config_dir.must_equal '/path/to/scenarios.d'
+        end
+      end
+    end
+
+    describe "#last_scenario_link" do
+      specify { manager.last_scenario_link.must_equal '/path/to/scenarios.d/last_scenario.yaml' }
+    end
+
+    describe "#scenario_changed?" do
+      it "detects changed scenario" do
+        manager.stub(:previous_scenario, '/path/to/scenarios.d/last.yaml') do
+          manager.scenario_changed?('/path/to/scenarios.d/foreman.yaml').must_equal true
+        end
+      end
+
+      it "detects unchanged scenario" do
+        manager.stub(:previous_scenario, '/path/to/scenarios.d/foreman.yaml') do
+          manager.scenario_changed?('/path/to/scenarios.d/foreman.yaml').must_equal false
+        end
+      end
+
+      specify { manager.scenario_changed?('/path/to/scenarios.d/foreman.yaml').must_equal false }
+    end
+
+    describe "#list_available_scenarios" do
+      let(:input) { StringIO.new }
+      let(:output) { StringIO.new }
+      let(:available_scenarios) do
+        {
+          '/path/first.yaml' => { :name => 'First', :description => 'First scenario'},
+          '/path/second.yaml' => { :name => 'Second', :description => 'Second scenario'}
+        }
+      end
+      before do
+        $terminal.instance_variable_set '@output', output
+      end
+
+      it "prints available scenarios" do
+        manager.stub(:available_scenarios, available_scenarios) do
+          must_exit_with_code(0) { manager.list_available_scenarios }
+          must_be_on_stdout(output, 'First (use: --scenario first)')
+          must_be_on_stdout(output, 'Second (use: --scenario second)')
+        end
+      end
+
+      it "prints no available scenarios" do
+        manager.stub(:available_scenarios, {}) do
+          must_exit_with_code(0) { manager.list_available_scenarios }
+          must_be_on_stdout(output, 'No available scenarios found')
+        end
+      end
+    end
+
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -164,9 +164,12 @@ class Minitest::Spec
   before do
     Kafo::KafoConfigure.config   = Kafo::Configuration.new(ConfigFileFactory.build('basic', BASIC_CONFIGURATION).path)
     Kafo::KafoConfigure.root_dir = File.dirname(__FILE__)
-    Kafo::KafoConfigure.logger   = Kafo::Logger.new
-    Kafo::KafoConfigure.modules_dir = 'test/fixtures/modules'
+    Kafo::KafoConfigure.exit_handler = Kafo::ExitHandler.new
     Kafo::Logger.loggers = []
+    Kafo::KafoConfigure.logger   = Kafo::Logger.new
+    Kafo::KafoConfigure.module_dirs = ['test/fixtures/modules']
+    Kafo::Logger.buffer.clear
+    Kafo::Logger.error_buffer.clear
   end
 end
 


### PR DESCRIPTION
The PR contains implementation of scenarios. Things that are missing follows:
 * [x] tests
 * [x] code clean up
 * [ ] ~~handling of installation with different scenario (exit vs. answer file merge)~~ will be addressed in separate PR
 * [x] support for existing config file foremat (so that existing foreman_installer can run with new Kafo)
 * [x] KafoWizards packaging https://github.com/theforeman/kafo_wizards

Summary of changes:
 * Foreman installer binary should be replaced with 
```ruby
#!/usr/bin/env ruby
require 'rubygems'
require 'kafo'

# where to find scenarios
CONFIG_DIR = '/etc/foreman/installer-scenarios.d/'

# Run the install
@result = Kafo::KafoConfigure.run

# handle exit code when help was invoked or installer ended with '2' (success in puppet)
if @result.nil? || (!@result.config.app[:detailed_exitcodes] && @result.exit_code == 2)
  exit(0)
else
  exit(@result.exit_code)
end
```
this is dropping support for config files in ./config. Do we want it?

 * config directory was changed to 
```
/etc/foreman
├── installer-scenarios.d
│   ├── foreman-installer-answers.yaml
│   ├── foreman-installer.yaml
│   ├── foreman-proxy-answers.yaml
│   ├── foreman-proxy.yaml
│   └── last_scenario.yaml -> /etc/foreman/installer-scenarios.d/foreman-proxy.yaml
...
```
 * Config file format changes:
   * `:modules_dir` was renamed to `:module_dirs` and should be array. (`:modules_dir` still works)
   * `:name` is mandatory name of the scenario
   * `:description` optional scenario description
   * `:check_dirs` was added accepting list of dirs with checks, defaults to current (installer_root)/checks 

Mapping stays unchanged, installer is looking for the manifests in the module_dirs (first occurence is used). I hope puppet does the same later :) (needs to be checked)  

 * There are two new `foreman-installer` options and the behavior changed slightly
```
$> foreman-installer
Scenario was not selected, can not continue. Use --list-scenarios to list available options.
```

List of scenarios
```
$> foreman-installer --list-scenarios
Available scenarios
  Foreman (use: --scenario foreman-installer)
        Basic and most generic installation of Foreman
  Foreman Proxy (use: --scenario foreman-proxy)
        Install Foreman proxy without Foreman
```

Installer help
```
$> foreman-installer --scenario foreman-proxy -h
Usage:
    foreman-installer [OPTIONS]

Options:

= Generic:
     ...
    -S, --scenario SCENARIO       Use installation scenario
    --list-scenarios LIST_SCENARIOS List available installation scenaraios
    ...
```

Installer in interactive mode
```
$> foreman-installer -i

Select installation scenario

Please select one of the pre-set installation scenarios. You can customize your installtion later during the installtion.

Available actions:
1. Foreman: Basic and most generic installation of Foreman
2. Foreman Proxy: Install Foreman proxy without Foreman
3. Cancel Installation
Your choice: 
```

Sample installer run
```
$> foreman-installer --scenario foreman-proxy
 /Stage[main]/Foreman_proxy::Register/Foreman_smartproxy[scenarios.my.lan]: Could not evaluate: Proxy scenarios.my.lan cannot be registered (401 Unauthorized): N/A
Installing             Done                                               [100%] [...............................................................................................................................]
  Something went wrong! Check the log for ERROR-level output
  * Foreman Proxy is running at https://scenarios.my.lan:8443
  The full log is at /var/log/foreman-installer/foreman-installer.log
```

