### PR TITLE
bump logging and highline upper version limits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,11 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in kafo.gemspec
 gemspec
+
+  if RUBY_VERSION >= '2.0'
+    gem 'logging', '< 3.0.0'
+    gem 'highline', '>= 1.6.21', '< 2.0'
+  else
+    gem 'logging', '< 2.0.0'
+    gem 'highline', '>= 1.6.21', '< 1.7'
+  end

--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -27,11 +27,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kafo_parsers'
   spec.add_dependency 'puppet', '< 4.0.0'
   # better logging
-  spec.add_dependency 'logging', '< 2.0.0'
+  spec.add_dependency 'logging', '< 3.0.0'
   # CLI interface
   spec.add_dependency 'clamp', '>= 0.6.2'
   # interactive mode
-  spec.add_dependency 'highline', '>= 1.6.21', '< 1.7'
+  spec.add_dependency 'highline', '>= 1.6.21', '< 2.0'
   # ruby progress bar
   spec.add_dependency 'powerbar'
 end


### PR DESCRIPTION
As newer Debian/Ubuntu versions are already bringing newer versions in their upstream OS repos, this is required to not run into problems regarding packaging and is related to issue 11280 for hammer/apipie-bindings.

I tested this with logger 2.0.0 and highline 1.7.2 - logging and progress bars seem unaffected.