### PR TITLE
Dump default parameter values using --noop

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -104,7 +104,7 @@ module Kafo
         temp_dir = Dir.mktmpdir(nil, app[:default_values_dir])
         KafoConfigure.exit_handler.register_cleanup_path temp_dir
         @logger.info 'Loading default values from puppet modules...'
-        command = PuppetCommand.new("$temp_dir=\"#{temp_dir}\" #{includes} dump_values(#{params})").append('2>&1').command
+        command = PuppetCommand.new("$temp_dir=\"#{temp_dir}\" #{includes} dump_values(#{params})", ['--noop']).append('2>&1').command
         result = `#{command}`
         @logger.debug result
         unless $?.exitstatus == 0


### PR DESCRIPTION
When running Puppet to dump default parameter values, use the --noop
flag as a backup measure to ensure that resources in "params" classes
have no way of making actual system state changes.  The dump_values
parser function is unaffected.

---

https://github.com/theforeman/puppet-foreman_proxy/pull/192 is the module issue that has been fixed, but this will act as a safety net in case it happens again.  Run `foreman-installer -v` on nightly now to see the bug where a change happens while dumping default values.