### PR TITLE
Fixes #13046 - add pre_migrations hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@ You may need to add new features to the installer. Kafo provides a simple hook
 mechanism that allows you to run custom code at 6 different occasions.
 We currently support the following hooks.
 
+* pre_migrations - just after kafo reads its configuration - useful for config file updates. Only in this stage it is posible to request config reload (`Kafo.request_config_reload`) to get in our changes
 * boot - before kafo is ready to work, useful for adding new installer arguments, but logger won't work yet
 * init - just after hooking is initialized and kafo is configured, parameters have no values yet
 * pre_values - just before value from CLI is set to parameters (they already have default values)

--- a/bin/kafo-export-params
+++ b/bin/kafo-export-params
@@ -33,7 +33,7 @@ module Kafo
       c                         = Configuration.new(config, false)
       KafoConfigure.config      = c
       KafoConfigure.root_dir    = File.expand_path(c.app[:installer_dir])
-      KafoConfigure.modules_dir = File.expand_path(c.app[:modules_dir])
+      KafoConfigure.module_dirs = File.expand_path(c.app[:module_dirs])
       KafoConfigure.logger      = Logger.new(STDOUT)
 
       exporter = self.class.const_get(format.capitalize).new(c)

--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'ansi'
   spec.add_development_dependency 'minitest', '~> 4.0'
   spec.add_development_dependency 'simplecov', '< 0.9'
   spec.add_development_dependency 'ci_reporter', '~> 1.9.0'

--- a/lib/kafo/exit_handler.rb
+++ b/lib/kafo/exit_handler.rb
@@ -25,7 +25,7 @@ module Kafo
       @exit_code = translate_exit_code(code)
       block.call if block
       KafoConfigure.logger.debug "Exit with status code: #{@exit_code} (signal was #{code})"
-      KafoConfigure.logger.dump_errors
+      KafoConfigure.logger.dump_errors unless KafoConfigure.verbose
       cleanup
       Kernel.exit(@exit_code)
     end

--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -2,6 +2,7 @@ require 'kafo/hook_context'
 
 module Kafo
   class Hooking
+    # pre_migrations - just after kafo reads its configuration - useful for config file updates. Only in this stage it is posible to request config reload (`Kafo.request_config_reload`) to get in our changes
     # boot - before kafo is ready to work, useful for adding new app arguments, logger won't work yet
     # init - just after hooking is initialized and kafo is configured, parameters have no values yet
     # pre_values - just before value from CLI is set to parameters (they already have default values)
@@ -9,7 +10,7 @@ module Kafo
     # pre_commit - after validations or interactive wizard have completed, all parameter values are set but not yet stored in the answer file
     # pre - just before puppet is executed to converge system
     # post - just after puppet is executed to converge system
-    TYPES = [:boot, :init, :pre, :post, :pre_values, :pre_validations, :pre_commit]
+    TYPES = [:pre_migrations, :boot, :init, :pre, :post, :pre_values, :pre_validations, :pre_commit]
 
     attr_accessor :hooks, :kafo
 
@@ -51,6 +52,10 @@ module Kafo
         logger.debug "Hook #{name} returned #{result.inspect}"
       end
       logger.info "All hooks in group #{group} finished"
+    end
+
+    def register_pre_migrations(name, &block)
+      register(:pre_migrations, name, &block)
     end
 
     def register_boot(name, &block)

--- a/lib/kafo/logger.rb
+++ b/lib/kafo/logger.rb
@@ -52,7 +52,7 @@ module Kafo
       end
 
       logger   = Logging.logger['main']
-      filename = "#{KafoConfigure.config.app[:log_dir]}/#{KafoConfigure.config.app[:log_name] || 'configure.log'}"
+      filename = KafoConfigure.config.log_file
       begin
         logger.appenders = ::Logging.appenders.rolling_file('configure',
                                                             :filename => filename,
@@ -66,14 +66,14 @@ module Kafo
       end
 
       logger.level = KafoConfigure.config.app[:log_level]
-      self.loggers = [logger]
+      self.loggers << logger
 
-      setup_fatal_logger(color_layout)
+      setup_fatal_logger(color_layout) unless loggers.detect {|l| l.name == 'verbose'}
     end
 
     def self.setup_verbose
       logger           = Logging.logger['verbose']
-      logger.level     = KafoConfigure.config.app[:verbose_log_level]
+      logger.level     = (KafoConfigure.config && KafoConfigure.config.app[:verbose_log_level]) || :info
       layout           = color_layout
       logger.appenders = [::Logging.appenders.stdout(:layout => layout)]
       self.loggers<< logger
@@ -94,7 +94,7 @@ module Kafo
     def self.dump_errors
       setup_fatal_logger(color_layout) if loggers.empty?
       unless self.error_buffer.empty?
-        loggers.each { |logger| logger.error 'Repeating errors encountered during run:' }
+        loggers.each { |logger| logger.error 'Errors encountered during run:' }
         self.dump_buffer(self.error_buffer)
       end
     end

--- a/test/kafo/configuration_test.rb
+++ b/test/kafo/configuration_test.rb
@@ -71,5 +71,31 @@ module Kafo
         end
       end
     end
+
+    describe '#migrate_configuration' do
+
+      let(:keys) { [:log_dir, :log_name, :log_level, :no_prefix, :default_values_dir,
+          :colors, :color_of_background, :custom, :password, :verbose_log_level] }
+
+      before do
+        (keys + [:description]).each { |key| old_config.app[key] = 'old value' }
+      end
+
+      it 'migrates values from other configuration' do
+        basic_config.migrate_configuration(old_config)
+        keys.each { |key| basic_config.app[key].must_equal 'old value' }
+        basic_config.app[:description].wont_equal 'old value'
+      end
+
+      it 'migrates values from other configuration except those marked to skip' do
+        basic_config.migrate_configuration(old_config, :skip => [:log_name])
+        basic_config.app[:log_name].wont_equal 'old value'
+      end
+
+      it 'migrates values from other configuration plus those marked to add' do
+        basic_config.migrate_configuration(old_config, :with => [:description])
+        basic_config.app[:description].must_equal 'old value'
+      end
+    end
   end
 end


### PR DESCRIPTION
- added `pre_migration` hook which allow us to fiddle with installer config and reload it to get the changes in 
- moved confirmation of scenario change to later stage (after the migrations)
- added flush of logs even if kafo ends before logger setup. 
- fixed minor issues in logging setup when verbose is used