### PR TITLE
Fixes #10292 - Add support for scenario updates (migrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,10 +286,35 @@ provided by Kafo can be used and customized to satisfy your needs
 ```
 
 ### Scenario as an installer plugin
+
 Scenarios were designed to make it possible to package them separately as optional installer extension.  
 Config files are located in separate directory which makes packaging of additional scenarios easy.
 Configuration of paths to modules, checks and hooks accepts multiple directories
 so it is possible to bundle your scenario with additional modules, hooks and checks.
+
+### Updating scenarios
+
+As your project grows you may need to change your installer modules or add new ones. To make upgrades of existing installations easier
+Kafo has support for scenario migrations. Migrations are ruby scripts similar to hooks and are located
+in `<config>/installer-scenarios.d/your-scenario.migrations/` so each scenario has its own set of independent migrations.
+During its initialization the installer checks for migrations that were not applied yet. It happens exactly between execution of `pre-migrations` and `boot` hooks.
+The installer stores names of applied migrations in `<config>/installer-scenarios.d/your-scenario.migrations/.applied` to avoid runnig the migrations multiple times.  
+It is recommended to prefix the migration names with `date +%y%m%d%H%M%S` to avoid migration ordering issues.
+
+In a migration you can modify the scenario configuration as well as the answer file. The changed configs are stored immediately after all the migrations were applied.
+Note that `--noop` and `--dont-save-answers` has no effect on migrations.
+
+Sample migration adding new module could look like as follows:
+
+```bash
+  cat <<EOF > "/etc/foreman/installer-scenarios.d/foreman-installer.migrations/`date +%y%m%d%H%M%S`-gutterball.rb"
+  scenario[:mapping]['katello::plugin::gutterball'] = {
+      :dir_name => 'katello',
+      :manifest_name => 'plugin/gutterball'
+  }
+  answers['katello::plugin::gutterball'] = true
+  EOF
+```
 
 ## Documentation
 

--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -240,6 +240,22 @@ module Kafo
       @data
     end
 
+    def run_migrations
+      migrations = Kafo::Migrations.new(migrations_dir)
+      @app, @data = migrations.run(app, answers)
+      if migrations.migrations.count > 0
+        @modules = nil # force the lazy loaded modules to reload next time they are used
+        save_configuration(app)
+        store(answers)
+        migrations.store_applied
+        @logger.info("#{migrations.migrations.count} migration/s were applied. Updated configuration was saved.")
+      end
+    end
+
+    def migrations_dir
+      @config_file.gsub(/\.yaml$/, '.migrations')
+    end
+
     private
 
     def custom_storage

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -12,6 +12,7 @@ require 'clamp'
 require 'kafo/color_scheme'
 require 'kafo_parsers/exceptions'
 require 'kafo/exceptions'
+require 'kafo/migrations'
 require 'kafo/configuration'
 require 'kafo/logger'
 require 'kafo/string_helper'
@@ -54,7 +55,9 @@ module Kafo
       setup_config(config_file)
 
       self.class.hooking.execute(:pre_migrations)
+
       # run migrations
+      self.class.config.run_migrations
 
       # reload config
       if @config_reload_requested
@@ -68,6 +71,7 @@ module Kafo
         scenario_manager.check_scenario_change(self.class.config_file)
         if scenario_manager.scenario_changed?(self.class.config_file)
           prev_config = scenario_manager.load_configuration(scenario_manager.previous_scenario)
+          prev_config.run_migrations
           self.class.config.migrate_configuration(prev_config, :skip => [:log_name])
           setup_config(self.class.config_file)
           self.class.logger.info("Due to scenario change the configuration (#{self.class.config_file}) was updated with #{scenario_manager.previous_scenario} and reloaded.")

--- a/lib/kafo/migration_context.rb
+++ b/lib/kafo/migration_context.rb
@@ -1,0 +1,21 @@
+module Kafo
+  class MigrationContext
+
+    attr_accessor :scenario, :answers
+
+    def self.execute(scenario, answers, &migration)
+      context = new(scenario, answers)
+      context.instance_eval(&migration)
+      return context.scenario, context.answers
+    end
+
+    def initialize(scenario, answers)
+      @scenario = scenario
+      @answers = answers
+    end
+
+    def logger
+      KafoConfigure.logger
+    end
+  end
+end

--- a/lib/kafo/migrations.rb
+++ b/lib/kafo/migrations.rb
@@ -1,0 +1,54 @@
+require 'yaml'
+require 'kafo/migration_context'
+
+module Kafo
+  class Migrations
+
+    attr_reader :migrations
+
+    def initialize(migrations_dir)
+      @migrations_dir = migrations_dir
+      @migrations = {}
+      @applied_file = File.join(@migrations_dir, '.applied')
+      load_migrations
+    end
+
+    def applied
+      @applied ||= load_applied
+    end
+
+    def load_migrations
+      Dir.glob(@migrations_dir + "/*.rb").each do |file|
+        next if applied.include?(File.basename(file))
+        KafoConfigure.logger.debug "Loading migration #{file}"
+        migration = File.read(file)
+        migration_block = proc { instance_eval(migration, file, 1) }
+        add_migration(file, &migration_block)
+      end
+    end
+
+    def add_migration(name, &block)
+      @migrations[name] = block
+    end
+
+    def run(scenario, answers)
+      @migrations.keys.sort.each do |name|
+        KafoConfigure.logger.debug "Executing migration #{name}"
+        migration = @migrations[name]
+        scenario, answers = Kafo::MigrationContext.execute(scenario, answers, &migration)
+        applied << File.basename(name.to_s)
+      end
+      return scenario, answers
+    end
+
+    def store_applied
+      File.open(@applied_file, 'w') { |f| f.write(applied.to_yaml) }
+    end
+
+    private
+
+    def load_applied
+      File.exist?(@applied_file) ? YAML.load_file(@applied_file) : []
+    end
+  end
+end

--- a/test/config_file_factory.rb
+++ b/test/config_file_factory.rb
@@ -2,12 +2,25 @@ require 'tempfile'
 
 class ConfigFileFactory
   @configs = {}
+  @answers = {}
 
   def self.build(key, content)
-    @configs[key] or @configs[key] = build_file(content)
+    @configs[key] ||= build_file(content)
   end
 
   def self.build_file(content)
+    match = /:answer_file:\ (.*)/.match(content)
+    if match
+      content.gsub!(/:answer_file:\ .*/, ":answer_file: #{answers(match[1]).path}")
+    end
+    temp_file('testing_config', content)
+  end
+
+  def self.answers(file)
+    @answers[file] ||= temp_file('testing_ansers', File.read(file))
+  end
+
+  def self.temp_file(name, content)
     f = Tempfile.open(['testing_config', '.yaml'])
     f.write content
     f.close

--- a/test/kafo/migration_context_test.rb
+++ b/test/kafo/migration_context_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+module Kafo
+  describe MigrationContext do
+    let(:context) { MigrationContext.new({}, {}) }
+
+    describe "api" do
+      specify { context.respond_to?(:logger) }
+      specify { context.respond_to?(:scenario) }
+      specify { context.respond_to?(:answers) }
+    end
+  end
+end

--- a/test/kafo/migrations_test.rb
+++ b/test/kafo/migrations_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Kafo
+  describe Migrations do
+    let(:migrations) { Migrations.new('some_directory') }
+    let(:dummy_logger) { DummyLogger.new }
+
+    describe '#run' do
+
+      before do
+        KafoConfigure.logger = dummy_logger
+        migrations.add_migration(:no1) { logger.error 's1' }
+        migrations.add_migration(:no2) { logger.error 's2' }
+        migrations.run({}, {})
+      end
+
+      it 'executes all the migrations' do
+        dummy_logger.rewind
+        dummy_logger.error.read.must_match /.*s1.*s2.*/m
+      end
+
+      it 'knows the applied migrations' do
+        migrations.applied.must_equal ['no1', 'no2']
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Kafo::Configuration was extended vith ability to run migrations stored in installer-scenarios.d/scenario.migrations/
- each scenario has own set of migrations
- migrations are run just once
- migrations are run after 'pre-migrations' hooks
- migrations run within limited migration context