### PR TITLE
Fixes #13850 - print help without --force for inactive scenario

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -78,7 +78,7 @@ module Kafo
 
       if scenario_manager.configured?
         scenario_manager.check_scenario_change(self.class.config_file)
-        if scenario_manager.scenario_changed?(self.class.config_file)
+        if scenario_manager.scenario_changed?(self.class.config_file) && !self.class.in_help_mode?
           prev_config = scenario_manager.load_configuration(scenario_manager.previous_scenario)
           prev_config.run_migrations
           self.class.config.migrate_configuration(prev_config, :skip => [:log_name])
@@ -164,6 +164,10 @@ module Kafo
 
     def self.exit_code
       self.exit_handler.exit_code
+    end
+
+    def self.in_help_mode?
+      ARGV.include?('--help') || ARGV.include?('--full-help') || ARGV.include?('-h')
     end
 
     def exit_code

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -141,26 +141,25 @@ module Kafo
     end
 
     def confirm_scenario_change(new_scenario)
-      unless ARGV.include?('--force')
-        if (ARGV & ['--interactive', '-i']).any?
-          show_scenario_diff(@previous_scenario, new_scenario)
+      if (ARGV & ['--interactive', '-i']).any?
+        show_scenario_diff(@previous_scenario, new_scenario)
 
-          wizard = KafoWizards.wizard(:cli, 'Confirm installation scenario selection',
-            :description => "You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Please confirm that you want to proceed.")
-          wizard.entries << wizard.factory.button(:proceed, :label => 'Proceed with selected installation scenario', :default => false)
-          wizard.entries << wizard.factory.button(:cancel, :label => 'Cancel Installation', :default => true)
-          result = wizard.run
-          if result == :cancel
-            say 'Installation was cancelled by user'
-            dump_log_and_exit(0)
-          end
-        else
-          message = "You are trying to replace existing installation with different scenario. This may lead to unpredictable states. " +
-          "Use --force to override. You can use --compare-scenarios to see the differences"
-          KafoConfigure.logger.error(message)
-          dump_log_and_exit(:scenario_error)
+        wizard = KafoWizards.wizard(:cli, 'Confirm installation scenario selection',
+          :description => "You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Please confirm that you want to proceed.")
+        wizard.entries << wizard.factory.button(:proceed, :label => 'Proceed with selected installation scenario', :default => false)
+        wizard.entries << wizard.factory.button(:cancel, :label => 'Cancel Installation', :default => true)
+        result = wizard.run
+        if result == :cancel
+          say 'Installation was cancelled by user'
+          dump_log_and_exit(0)
         end
+      elsif !ARGV.include?('--force') && !KafoConfigure.in_help_mode?
+        message = "You are trying to replace existing installation with different scenario. This may lead to unpredictable states. " +
+        "Use --force to override. You can use --compare-scenarios to see the differences"
+        KafoConfigure.logger.error(message)
+        dump_log_and_exit(:scenario_error)
       end
+      true
     end
 
     def print_scenario_diff(prev_conf, new_conf)

--- a/test/kafo/scenario_manager_test.rb
+++ b/test/kafo/scenario_manager_test.rb
@@ -149,6 +149,52 @@ module Kafo
       end
     end
 
+    describe '#confirm_scenario_change' do
+      let(:basic_config_file) { ConfigFileFactory.build('basic', BASIC_CONFIGURATION).path }
+      let(:new_config) { Kafo::Configuration.new(basic_config_file, false) }
+
+      before :all do
+        @argv = ARGV
+        ARGV.clear
+      end
+
+      after :all do
+        ARGV.clear
+        ARGV.concat(@argv)
+      end
+
+      it 'prints error and exits when not forced' do
+        log_device = DummyLogger.new
+        Logger.loggers = [log_device]
+        must_exit_with_code(Kafo::ExitHandler.new.error_codes[:scenario_error]) do
+          capture_io { manager.confirm_scenario_change(new_config) }
+        end
+        log_device.rewind
+        errors = log_device.error.read
+        errors.must_match /You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Use --force to override. You can use --compare-scenarios to see the differences/
+      end
+
+      it 'passes when forced (--force)' do
+        ARGV << '--force'
+        assert manager.confirm_scenario_change(new_config)
+      end
+
+      it 'passes when printing help (--help)' do
+        ARGV << '--help'
+        assert manager.confirm_scenario_change(new_config)
+      end
+
+      it 'passes when printing full help (--full-help)' do
+        ARGV << '--full-help'
+        assert manager.confirm_scenario_change(new_config)
+      end
+
+      it 'passes when printing help (-h)' do
+        ARGV << '-h'
+        assert manager.confirm_scenario_change(new_config)
+      end
+    end
+
     describe '#print_scenario_diff' do
       let(:basic_config_file) { ConfigFileFactory.build('basic', BASIC_CONFIGURATION).path }
       let(:new_config) { Kafo::Configuration.new(basic_config_file, false) }


### PR DESCRIPTION
`git diff HEAD^ -w` reveal better view on what has changed