### PR TITLE
Fixes #14373 - adding ability to disable and enable scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The installer stores names of applied migrations in `<config>/installer-scenario
 It is recommended to prefix the migration names with `date +%y%m%d%H%M%S` to avoid migration ordering issues.
 
 In a migration you can modify the scenario configuration as well as the answer file. The changed configs are stored immediately after all the migrations were applied.
-If you just want to apply the migrations you can use `--migrations-only` switch. 
+If you just want to apply the migrations you can use `--migrations-only` switch.
 Note that `--noop` and `--dont-save-answers` has no effect on migrations.
 
 Sample migration adding new module could look like as follows:
@@ -316,6 +316,20 @@ Sample migration adding new module could look like as follows:
   answers['katello::plugin::gutterball'] = true
   EOF
 ```
+
+### Enabling/disabling scenarios
+
+Scenarios that are deprecated or wanted to be hidden on the system can be disabled with:
+
+```bash
+  foreman-installer --disable-scenario deprecated-scenario
+  Scenario deprecated-scenario was disabled.
+```
+The disabled scenario is not shown in the scenario list and is prevented from being installed.
+It is not deleted from the file system however so the custom values in the answer file are preserved
+and e.g. migration to new scenario is still possible.
+
+Disabled scenario can be enabled back again with `foreman-installer --enable-scenario SCENARIO`.
 
 ## Documentation
 
@@ -913,7 +927,7 @@ Other exit codes that can be returned:
 * '24' means that your answer file asks for puppet module that you did not provide
 * '25' means that kafo could not get default values from puppet
 * '26' means that kafo could not find the specified scenario
-* '27' means that kafo found previous installation that has different scenario than is the specified scenario  
+* '27' means that kafo found found scenario configuration error that prevents installation from continuing  
 * '130' user interrupt (^C)
 
 ## Running Puppet Profiling

--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -12,6 +12,7 @@ module Kafo
     DEFAULT = {
         :name                 => '',
         :description          => '',
+        :enabled              => true,
         :log_dir              => '/var/log/kafo',
         :log_name             => 'configuration.log',
         :log_level            => 'info',

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -52,6 +52,8 @@ module Kafo
 
       # Handle --list-scenarios before we need them
       scenario_manager.list_available_scenarios if ARGV.include?('--list-scenarios')
+      scenario_manager.check_enable_scenario
+      scenario_manager.check_disable_scenario
       setup_config(config_file)
 
       self.class.hooking.execute(:pre_migrations)
@@ -270,6 +272,8 @@ module Kafo
       self.class.app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
                             :default => 'info'
       self.class.app_option ['-S', '--scenario'], 'SCENARIO', 'Use installation scenario'
+      self.class.app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario'
+      self.class.app_option ['--enable-scenario'], 'SCENARIO', 'Enable installation scenario'
       self.class.app_option ['--list-scenarios'], :flag, 'List available installation scenaraios'
       self.class.app_option ['--force'], :flag, 'Force change of installation scenaraio'
       self.class.app_option ['--compare-scenarios'], :flag, 'Show changes between last used scenario and the scenario specified with -S or --scenario argument'

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -16,7 +16,7 @@ module Kafo
       @available_scenarios ||= Dir.glob(File.join(config_dir, '*.yaml')).reject { |f| f =~ /#{last_scenario_link}$/ }.inject({}) do |scns, scn_file|
         begin
           content = YAML.load_file(scn_file)
-          if content.is_a?(Hash) && content.has_key?(:answer_file)
+          if content.is_a?(Hash) && content.has_key?(:answer_file) && content.fetch(:enabled, true)
             # add scenario name for legacy configs
             content[:name] = File.basename(scn_file, '.yaml') unless content.has_key?(:name)
             scns[scn_file] = content
@@ -75,14 +75,13 @@ module Kafo
       !!(defined?(CONFIG_DIR) && CONFIG_DIR)
     end
 
-    def scenario_from_args
+    def scenario_from_args(arg_name='--scenario|-S')
       # try scenario provided in the args via -S or --scenario
-      parsed = ARGV.join(" ").match /(--scenario|-S)(\s+|[=]?)(\S+)/
+      parsed = ARGV.join(" ").match /(#{arg_name})(\s+|[=]?)(\S+)/
       if parsed
         scenario_file = File.join(config_dir, "#{parsed[3]}.yaml")
         return scenario_file if File.exists?(scenario_file)
-        KafoConfigure.logger.fatal "Scenario (#{scenario_file}) was not found, can not continue"
-        KafoConfigure.exit(:unknown_scenario)
+        fail_now("Scenario (#{scenario_file}) was not found, can not continue", :unknown_scenario)
       end
     end
 
@@ -92,18 +91,11 @@ module Kafo
         select_scenario_interactively
       if scenario.nil?
         fail_now("Scenario was not selected, can not continue. Use --list-scenarios to list available options.", :unknown_scenario)
+      elsif !scenario_enabled?(scenario)
+        fail_now("Selected scenario is DISABLED, can not continue. Use --list-scenarios to list available options." \
+	        " You can also --enable-scenario SCENARIO to make the selected scenario available.", :scenario_error)
       end
       scenario
-    end
-
-    def scenario_from_args
-      # try scenario provided in the args via -S or --scenario
-      parsed = ARGV.join(" ").match /(--scenario|-S)(\s+|[=]?)(\S+)/
-      if parsed
-        scenario_file = File.join(config_dir, "#{parsed[3]}.yaml")
-        return scenario_file if File.exists?(scenario_file)
-        fail_now("Scenario (#{scenario_file}) was not found, can not continue", :unknown_scenario)
-      end
     end
 
     def show_scenario_diff(prev_scenario, new_scenario)
@@ -123,6 +115,28 @@ module Kafo
           KafoConfigure.logger.info "Scenario #{scenario} was selected"
         end
       end
+    end
+
+    def check_enable_scenario
+      scenario = scenario_from_args('--enable-scenario')
+      set_scenario_availability(scenario, true) if scenario
+    end
+
+    def check_disable_scenario
+      scenario = scenario_from_args('--disable-scenario')
+      set_scenario_availability(scenario, false) if scenario
+    end
+
+    def set_scenario_availability(scenario, available)
+      cfg = load_configuration(scenario)
+      cfg.app[:enabled] = available
+      cfg.save_configuration(cfg.app)
+      say "Scenario #{File.basename(scenario, ".yaml")} was #{available ? "enabled" : "disabled"}"
+      KafoConfigure.exit(0)
+    end
+
+    def scenario_enabled?(scenario)
+      load_configuration(scenario).app[:enabled]
     end
 
     def confirm_scenario_change(new_scenario)

--- a/test/config_file_factory.rb
+++ b/test/config_file_factory.rb
@@ -16,12 +16,16 @@ class ConfigFileFactory
     temp_file('testing_config', content)
   end
 
+  def self.build_answers(key, content)
+    @answers[key] ||= temp_file('testing_answers', content)
+  end
+
   def self.answers(file)
-    @answers[file] ||= temp_file('testing_ansers', File.read(file))
+    @answers[file] ||= temp_file('testing_answers', File.read(file))
   end
 
   def self.temp_file(name, content)
-    f = Tempfile.open(['testing_config', '.yaml'])
+    f = Tempfile.open([name, '.yaml'])
     f.write content
     f.close
     f

--- a/test/kafo/scenario_manager_test.rb
+++ b/test/kafo/scenario_manager_test.rb
@@ -35,6 +35,34 @@ module Kafo
       specify { manager.scenario_changed?('/path/to/scenarios.d/foreman.yaml').must_equal false }
     end
 
+    describe "#available_scenarios" do
+      def create_and_load_scenarios(content, filename='default.yaml')
+        Dir.mktmpdir do |dir|
+          File.open(File.join(dir, filename), 'w') { |f| f.write(content) }
+          ScenarioManager.new(dir).available_scenarios
+        end
+      end
+
+      it 'collects valid scenarios' do
+        scn = { :name => 'First', :description => 'First scenario', :answer_file => ''}
+        create_and_load_scenarios(scn.to_yaml).keys.count.must_equal 1
+      end
+
+      it 'skips scenarios without answer file' do
+        yaml_file = { :this_is => 'Not a scenario' }
+        create_and_load_scenarios(yaml_file.to_yaml).keys.must_be_empty
+      end
+
+      it 'skips disabled scenarios' do
+        scn = { :name => 'Second', :description => 'Second scenario', :answer_file => '', :enabled => false }
+        create_and_load_scenarios(scn.to_yaml).keys.must_be_empty
+      end
+
+      it 'skips non-yaml files' do
+        create_and_load_scenarios('some text file', 'text.txt').keys.must_be_empty
+      end
+    end
+
     describe "#list_available_scenarios" do
       let(:input) { StringIO.new }
       let(:output) { StringIO.new }
@@ -60,6 +88,27 @@ module Kafo
         manager.stub(:available_scenarios, {}) do
           must_exit_with_code(0) { manager.list_available_scenarios }
           must_be_on_stdout(output, 'No available scenarios found')
+        end
+      end
+    end
+
+    describe '#select_scenario' do
+      let(:input) { StringIO.new }
+      let(:output) { StringIO.new }
+      before do
+        $terminal.instance_variable_set '@output', output
+      end
+
+      it 'fails if disabled scenario is selected' do
+        disabled_answers = ConfigFileFactory.build_answers('disabled', {}.to_yaml)
+        disabled_scn = { :name => 'Disabled', :description => 'Disabled scenario', :answer_file => disabled_answers.path, :enabled => false }
+        scn_file = ConfigFileFactory.build('disabled', disabled_scn.to_yaml).path
+
+        manager.stub(:scenario_from_args, scn_file) do
+          must_exit_with_code(:scenario_error) { manager.select_scenario }
+          must_be_on_stdout(output, 'Selected scenario is DISABLED, can not continue.')
+          must_be_on_stdout(output, 'Use --list-scenarios to list available options.')
+          must_be_on_stdout(output, 'You can also --enable-scenario SCENARIO to make the selected scenario available.')
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -174,6 +174,7 @@ class Minitest::Spec
 end
 
 def must_exit_with_code(code, &block)
+  code = (Kafo::ExitHandler.new.error_codes[code] || code) if code.is_a?(Symbol)
   begin
     block.call
   rescue SystemExit => e


### PR DESCRIPTION
Sample installer session demoing the feature:
```bash
[root@kafotest ~]# foreman-installer --list-scenarios
Available scenarios
  Foreman (use: --scenario foreman)
        Default installation of Foreman
  Capsule (use: --scenario capsule)
        Install a stand-alone Capsule.
  Katello (use: --scenario katello)
        Install Foreman with Katello

[root@kafotest ~]# foreman-installer --disable-scenario capsule
Scenario capsule was disabled

[root@kafotest ~]# foreman-installer --list-scenarios
Available scenarios
  Foreman (use: --scenario foreman)
        Default installation of Foreman
  Katello (use: --scenario katello)
        Install Foreman with Katello

[root@kafotest ~]# foreman-installer -S capsule
ERROR: Selected scenario is DISABLED, can not continue. Use --list-scenarios to list available options. You can also --enable-scenario SCENARIO to make the selected scenario available.

[root@kafotest ~]# foreman-installer --enable-scenario capsule
Scenario capsule was enabled

[root@kafotest ~]# foreman-installer --list-scenarios
Available scenarios
  Foreman (use: --scenario foreman)
        Default installation of Foreman
  Capsule (use: --scenario capsule)
        Install a stand-alone Capsule.
  Katello (use: --scenario katello)
        Install Foreman with Katello
```