### PR TITLE
Fix Puppet module tests that weren't being run

### DIFF
--- a/test/kafo/puppet_module_test.rb
+++ b/test/kafo/puppet_module_test.rb
@@ -85,19 +85,23 @@ module Kafo
         end
       end
 
-      let(:groups) { parsed.groups.map(&:name) }
-      specify { groups.must_include('Parameters') }
-      specify { groups.must_include('Advanced parameters') }
-      specify { groups.must_include('Extra parameters') }
-      specify { groups.wont_include('MySQL') }
-      specify { groups.wont_include('Sqlite') }
+      describe "with groups" do
+        let(:groups) { parsed.groups.map(&:name) }
+        specify { groups.must_include('Parameters') }
+        specify { groups.must_include('Advanced parameters') }
+        specify { groups.must_include('Extra parameters') }
+        specify { groups.wont_include('MySQL') }
+        specify { groups.wont_include('Sqlite') }
+      end
 
-      let(:param_names) { parsed.params.map(&:name) }
-      specify { param_names.must_include('version') }
-      specify { param_names.must_include('debug') }
-      specify { param_names.must_include('remote') }
-      specify { param_names.must_include('file') }
-      specify { param_names.must_include('m_i_a') }
+      describe "parses parameter names" do
+        let(:param_names) { parsed.params.map(&:name) }
+        specify { param_names.must_include('version') }
+        specify { param_names.must_include('debug') }
+        specify { param_names.must_include('remote') }
+        specify { param_names.must_include('file') }
+        specify { param_names.must_include('m_i_a') }
+      end
     end
 
     describe "#primary_parameter_group" do


### PR DESCRIPTION
In MiniTest 4.x, there's an issue with specify blocks alongside
describe blocks at the same level, the specs inside the describe blocks
won't run. Move all tests in this level into describe blocks so they all
run.

---

https://gist.github.com/ed3fc43a89a21761cc08ef490ab0cfd0 is a simplified case if you want to look at the bug in minitest.  Version 5 works fine, but because it has random test ordering, it introduces a whole load more issues.  I've got most of them fixed on my minitest-5 branch, except for one around loading Puppet validation functions, but have now spent way too long on it...