### PR TITLE
fixes #14472 - require kafo/configuration in a standard way

### DIFF
--- a/bin/kafo-export-params
+++ b/bin/kafo-export-params
@@ -3,12 +3,10 @@ require 'rubygems'
 require 'ostruct'
 require 'clamp'
 require 'logging'
-require 'kafo/string_helper'
+require 'kafo/configuration'
 require 'kafo/exceptions'
+require 'kafo/string_helper'
 require 'logger'
-
-$LOAD_PATH.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'kafo'))
-require 'configuration'
 
 KafoConfigure = OpenStruct.new
 def KafoConfigure.exit(code)


### PR DESCRIPTION
Don't assume location of kafo lib/ dir in relation to the bin script.