### PR TITLE
refs #14448 - use kafo_parsers .find_available to load parser

### DIFF
--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kafo_wizards'
   spec.add_dependency 'ansi'
   # puppet module parsing
-  spec.add_dependency 'kafo_parsers'
-  spec.add_dependency 'puppet', '< 4.0.0'
+  spec.add_dependency 'kafo_parsers', '>= 0.1.0'
+  spec.add_development_dependency 'puppet', '< 4.0.0'
   # better logging
   spec.add_dependency 'logging', '< 3.0.0'
   # CLI interface

--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -86,7 +86,7 @@ module Kafo
     end
 
     def modules
-      @modules ||= @data.keys.map { |mod| PuppetModule.new(mod, KafoParsers::PuppetModuleParser, self).parse }.sort
+      @modules ||= @data.keys.map { |mod| PuppetModule.new(mod, PuppetModule.find_parser, self).parse }.sort
     end
 
     def root_dir
@@ -110,7 +110,7 @@ module Kafo
     end
 
     def add_module(name)
-      mod = PuppetModule.new(name, KafoParsers::PuppetModuleParser, self).parse
+      mod = PuppetModule.new(name, PuppetModule.find_parser, self).parse
       unless modules.map(&:name).include?(mod.name)
         mod.enable
         @modules << mod

--- a/lib/kafo/exceptions.rb
+++ b/lib/kafo/exceptions.rb
@@ -6,6 +6,9 @@ module Kafo
   class ConditionError < StandardError
   end
 
+  class ParserError < StandardError
+  end
+
   class TypeError < StandardError
   end
 end

--- a/test/kafo/puppet_module_test.rb
+++ b/test/kafo/puppet_module_test.rb
@@ -104,6 +104,16 @@ module Kafo
         specify { parsed.raw_data[:groups].must_equal [] }
       end
 
+      describe "with nil parser and no cache" do
+        let(:parser) { nil }
+        specify { Proc.new { parsed }.must_raise ParserError }
+      end
+
+      describe "without :none parser and no cache" do
+        let(:parser) { :none }
+        specify { Proc.new { parsed }.must_raise ParserError }
+      end
+
       describe "with groups" do
         let(:groups) { parsed.groups.map(&:name) }
         specify { groups.must_include('Parameters') }

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -1,3 +1,5 @@
+require 'kafo_parsers/parsers'
+
 class TestParser
   attr_reader :manifest_file
 
@@ -8,6 +10,6 @@ class TestParser
 
   # we use @manifest instead of manifest for testing
   def parse(manifest)
-    KafoParsers::PuppetModuleParser.parse(manifest_file)
+    KafoParsers::Parsers.find_available.parse(manifest_file)
   end
 end


### PR DESCRIPTION
By using the parser cache, the parser is now optional and will raise an
error at runtime if the cache misses and no parser is available.

---

Depends on https://github.com/theforeman/kafo_parsers/pull/14, but is also based on PR #135 as I'm trying to change the behaviour when we have both no parser and a cache.  I can swap this to do the available/soft deps change followed by the cache if preferred.