### PR TITLE
fixes #14452 - search /opt/puppetlabs/bin to run Puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ disable saving answer by passing a ```--dont-save-answers``` argument (or -d for
 
 Note that running ```--noop``` implies ```--dont-save-answers```.
 
+## Executing Puppet with multiple versions
+
+Kafo calls the `puppet` binary during an installer run to both compute default
+parameter values and perform the actual installer changes. This relies on
+`puppet` being in the PATH environment variable or as fallback, in
+`/opt/puppetlabs/bin`.
+
+When using Puppet via a Gemfile, Bundler should set up PATH to point at the
+gem version. If using a system/packaged version, it will typically find and
+execute /usr/bin/puppet from the regular PATH.
+
+When using an AIO/PC1 packaged version of Puppet, other versions of Puppet from
+PATH will be preferred if they exist, so they should either be removed or PATH
+set to prefer /opt/puppetlabs/bin, i.e. `export PATH=/opt/puppetlabs/bin:$PATH`.
+Debug logs from Kafo should indicate the full path of the binary used.
+
+Note that Kafo parsers supports specific versions of Puppet, and may require
+extra modules (such as puppet-strings on Puppet 4+) to parse manifests.
+
 ## Parameters prefixes
 
 As a default every module parameter is prefixed by the module name.

--- a/lib/kafo/puppet_command.rb
+++ b/lib/kafo/puppet_command.rb
@@ -25,7 +25,7 @@ module Kafo
           "echo '$kafo_config_file=\"#{@configuration.config_file}\" #{custom_answer_file} #{add_progress} #{@command}'",
           '|',
           "RUBYLIB=#{["#{@configuration.gem_root}/modules", ::ENV['RUBYLIB']].join(File::PATH_SEPARATOR)}",
-          "puppet apply #{@options.join(' ')} #{@suffix}",
+          "#{puppet_path} apply #{@options.join(' ')} #{@suffix}",
       ].join(' ')
       @logger.debug result
       result
@@ -43,6 +43,16 @@ module Kafo
           @configuration.module_dirs,
           @configuration.kafo_modules_dir,
       ].flatten.join(':')
+    end
+
+    def puppet_path
+      @puppet_path ||= begin
+        bin_name = 'puppet'
+        bin_path = (::ENV['PATH'].split(File::PATH_SEPARATOR) + ['/opt/puppetlabs/bin']).find do |path|
+          File.executable?(File.join(path, bin_name))
+        end
+        File.join([bin_path, bin_name].compact)
+      end
     end
   end
 end

--- a/test/kafo/puppet_command_test.rb
+++ b/test/kafo/puppet_command_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+module Kafo
+  describe PuppetModule do
+    before do
+      KafoConfigure.config = Configuration.new(ConfigFileFactory.build('basic', BASIC_CONFIGURATION).path)
+    end
+
+    let(:pc) { PuppetCommand.new '' }
+
+    describe "#command" do
+      describe "with defaults" do
+        specify { pc.command.must_be_kind_of String }
+        specify { pc.command.must_include 'puppet apply --modulepath /' }
+
+        specify { KafoConfigure.stub(:verbose, false) { pc.command.must_include '$kafo_add_progress=true' } }
+        specify { KafoConfigure.stub(:verbose, true) { pc.command.wont_include '$kafo_add_progress' } }
+
+        specify { KafoConfigure.stub(:temp_config_file, '/tmp/answer') { pc.command.must_include '$kafo_answer_file="/tmp/answer"' } }
+        specify { KafoConfigure.stub(:temp_config_file, nil) { pc.command.wont_include '$kafo_answer_file' } }
+      end
+
+      describe "with 'puppet' in PATH" do
+        specify do
+          ::ENV.stub(:[], '/usr/bin:/usr/local/bin') do
+            File.stub(:executable?, Proc.new { |path| path == '/usr/local/bin/puppet' }) do
+              pc.command.must_include '/usr/local/bin/puppet apply'
+            end
+          end
+        end
+      end
+
+      describe "with AIO 'puppet' only" do
+        specify do
+          ::ENV.stub(:[], '/usr/bin:/usr/local/bin') do
+            File.stub(:executable?, Proc.new { |path| path == '/opt/puppetlabs/bin/puppet' }) do
+              pc.command.must_include '/opt/puppetlabs/bin/puppet apply'
+            end
+          end
+        end
+      end
+
+      describe "with no 'puppet' found in PATH" do
+        specify { File.stub(:executable?, false) { pc.command.must_include ' puppet apply' } }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Preferring to search rather than just set PATH for improved logging, since the user will see in logs precisely which Puppet binary (if multiple exist) was used to run the command, which may help us in debugging.