### PR TITLE
Fixes #14758 - optimize progress bar for narrow terminal

### DIFF
--- a/lib/kafo/progress_bar.rb
+++ b/lib/kafo/progress_bar.rb
@@ -13,6 +13,7 @@ module Kafo
       @lines                                    = 0
       @all_lines                                = 0
       @total                                    = :unknown
+      @term_width                               = HighLine::SystemExtensions.terminal_size[0]
       @bar                                      = PowerBar.new
       @bar.settings.tty.infinite.template.main  = infinite_template
       @bar.settings.tty.finite.template.main    = finite_template

--- a/lib/kafo/progress_bars/black_white.rb
+++ b/lib/kafo/progress_bars/black_white.rb
@@ -5,7 +5,8 @@ module Kafo
       private
 
       def finite_template
-        'Installing'.ljust(22) + ' ${<msg>} [${<percent>%}] [${<bar>}]'
+        'Installing'.ljust(22) + ' ${<msg>} [${<percent>%}]' +
+        (@term_width >= 83 ? ' [${<bar>}]' : '')
       end
 
       def infinite_template

--- a/lib/kafo/progress_bars/colored.rb
+++ b/lib/kafo/progress_bars/colored.rb
@@ -16,7 +16,7 @@ module Kafo
         'Installing'.ljust(22) +
             ANSI::Code.yellow { ' ${<msg>}' } +
             ANSI::Code.green { ' [${<percent>%}]' } +
-            ' [${<bar>}]'
+            (@term_width >= 83 ? ' [${<bar>}]' : '')
       end
 
       def infinite_template


### PR DESCRIPTION
On terminal that has width < 83 chars the progress bar is reduced to just `[]` and tend to leave orphan `[` at the end of line. This patch removes progress bar for lines < 83 chars and leaves just the percent done in the output. This way it fits well to the standard 80x25 sized term.