### PR TITLE
refs #14758 - Nil check for term width

### DIFF
--- a/lib/kafo/progress_bars/black_white.rb
+++ b/lib/kafo/progress_bars/black_white.rb
@@ -6,7 +6,7 @@ module Kafo
 
       def finite_template
         'Installing'.ljust(22) + ' ${<msg>} [${<percent>%}]' +
-        (@term_width >= 83 ? ' [${<bar>}]' : '')
+        (@term_width.nil? || @term_width >= 83 ? ' [${<bar>}]' : '')
       end
 
       def infinite_template

--- a/lib/kafo/progress_bars/colored.rb
+++ b/lib/kafo/progress_bars/colored.rb
@@ -16,7 +16,7 @@ module Kafo
         'Installing'.ljust(22) +
             ANSI::Code.yellow { ' ${<msg>}' } +
             ANSI::Code.green { ' [${<percent>%}]' } +
-            (@term_width >= 83 ? ' [${<bar>}]' : '')
+            (@term_width.nil? || @term_width >= 83 ? ' [${<bar>}]' : '')
       end
 
       def infinite_template


### PR DESCRIPTION
katello-deploy is broken with: 

```
/usr/share/gems/gems/kafo-0.8.0/lib/kafo/progress_bars/colored.rb:19:in `finite_template'
undefined method `>=' for nil:NilClass (NoMethodError)
from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/progress_bar.rb:19:in `initialize'
from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/kafo_configure.rb:120:in `new'
from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/kafo_configure.rb:120:in `execute'
from /usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
from /usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/kafo_configure.rb:156:in `run'
from /sbin/foreman-installer:8:in `<main>'
```