### PR TITLE
fixes #14929 - fix foreman-installer due to kafo error

### DIFF
--- a/lib/kafo/progress_bar.rb
+++ b/lib/kafo/progress_bar.rb
@@ -13,7 +13,7 @@ module Kafo
       @lines                                    = 0
       @all_lines                                = 0
       @total                                    = :unknown
-      @term_width                               = HighLine::SystemExtensions.terminal_size[0]
+      @term_width                               = HighLine::SystemExtensions.terminal_size[0] || 0
       @bar                                      = PowerBar.new
       @bar.settings.tty.infinite.template.main  = infinite_template
       @bar.settings.tty.finite.template.main    = finite_template


### PR DESCRIPTION
During vagrant installation of katello scenario, kafo would error with:

```
Running shell command: foreman-installer --scenario katello-devel
stty: standard input: Inappropriate ioctl for device
/usr/share/gems/gems/kafo-0.8.0/lib/kafo/progress_bars/colored.rb:19:in `finite_template':
  undefined method `>=' for nil:NilClass (NoMethodError)
  from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/progress_bar.rb:19:in `initialize'
  from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/kafo_configure.rb:120:in `new'
  from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/kafo_configure.rb:120:in `execute'
  from /usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:68:in `run'
  from /usr/share/gems/gems/clamp-1.0.0/lib/clamp/command.rb:133:in `run'
  from /usr/share/gems/gems/kafo-0.8.0/lib/kafo/kafo_configure.rb:156:in `run'
  from /sbin/foreman-installer:8:in `<main>'
```