### PR TITLE
fixes #14937 - interpolate $param in validation args

### DIFF
--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kafo_wizards'
   spec.add_dependency 'ansi'
   # puppet module parsing
-  spec.add_dependency 'kafo_parsers', '>= 0.1.0'
+  spec.add_dependency 'kafo_parsers', '>= 0.1.1'
   spec.add_development_dependency 'puppet', '< 4.0.0'
   # better logging
   spec.add_dependency 'logging', '< 3.0.0'

--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -120,12 +120,8 @@ module Kafo
       args.map do |arg|
         if arg.to_s == "$#{self.name}"
           self.value
-        elsif arg.class.name == 'Puppet::Parser::AST::ASTArray'
-          interpret_validation_args(arg.to_a)
-        elsif arg.class.name == 'Puppet::Parser::AST::Concat'
-          interpret_validation_args(arg.value).join
-        elsif arg.respond_to? :value
-          arg.value
+        elsif arg.is_a? String
+          arg.gsub("$#{self.name}", self.value.to_s)
         else
           arg
         end


### PR DESCRIPTION
kafo_parsers 0.1.1 concatenates parsed strings itself, so variables in
validation argument strings are no longer separate AST objects and now
need to be replaced with gsub. Other AST remnants are removed to depend
on 0.1.1.

Remaining test failures will be fixed by https://github.com/theforeman/kafo_parsers/pull/22.