### PR TITLE
fixes #14941 - set Puppet RUBYLIB from kafo_modules_dir config

### DIFF
--- a/lib/kafo/puppet_command.rb
+++ b/lib/kafo/puppet_command.rb
@@ -24,7 +24,7 @@ module Kafo
       result = [
           "echo '$kafo_config_file=\"#{@configuration.config_file}\" #{custom_answer_file} #{add_progress} #{@command}'",
           '|',
-          "RUBYLIB=#{["#{@configuration.gem_root}/modules", ::ENV['RUBYLIB']].join(File::PATH_SEPARATOR)}",
+          "RUBYLIB=#{[@configuration.kafo_modules_dir, ::ENV['RUBYLIB']].join(File::PATH_SEPARATOR)}",
           "#{puppet_path} apply #{@options.join(' ')} #{@suffix}",
       ].join(' ')
       @logger.debug result


### PR DESCRIPTION
The patch at https://github.com/theforeman/foreman-packaging/blob/deb/1.11/dependencies/jessie/kafo/patches/fix_require_in_add_progress.diff can be deleted when this is released.