### PR TITLE
fixes #15071 - add --reset-* parameter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,25 @@ as key:value.
 When parsing the value, the first colon divides key and value. All other
 colons are ignored.
 
+## Resetting an argument
+
+Existing stored parameters can be reset back to their default value from the
+command line or interactive mode.  This deletes the stored value in the answers
+file and stores the default from the Puppet manifest in its place.
+
+The default value is the value set in, or computed by the Puppet params
+manifest. This will _not_ reset to any defaults specified in the answers file
+before running the Kafo-based installer, they are not kept.
+
+Using the CLI, a --reset option is available for every parameter, e.g.
+
+```bash
+bin/foreman-installer --reset-puppet-server-git-branch-map
+```
+
+The parameter can also be reset to the default in interactive mode, via the
+reset parameters sub-menu under each module.
+
 ## Grouping in interactive mode
 
 If your module has too many parameters you may find the grouping feature useful.

--- a/lib/kafo/help_builders/base.rb
+++ b/lib/kafo/help_builders/base.rb
@@ -82,7 +82,11 @@ module Kafo
       end
 
       def parametrization
-        @parametrization ||= Hash[@params.map { |p| [parametrize(p), p] }]
+        @parametrization ||= begin
+          @params.inject({}) do |h,p|
+            h.update(parametrize(p) => p, parametrize(p, 'reset-') => p)
+          end
+        end
       end
     end
   end

--- a/lib/kafo/help_builders/basic.rb
+++ b/lib/kafo/help_builders/basic.rb
@@ -4,8 +4,14 @@ module Kafo
   module HelpBuilders
     class Basic < Base
       def add_module(name, items)
-        data = by_parameter_groups(items)
+        data = by_parameter_groups(except_resets(items))
         add_list(module_header(name), data['Basic'])
+      end
+
+      private
+
+      def except_resets(items)
+        items.select { |i| !i.help.first.strip.start_with?('--reset-') || !i.help.last.strip.end_with?('to the default value') }
       end
     end
   end

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -301,6 +301,8 @@ module Kafo
         doc = param.doc.nil? ? 'UNDOCUMENTED' : param.doc.join("\n")
         self.class.option parametrize(param), '', doc,
                           :default => param.value, :multivalued => param.multivalued?
+        self.class.option parametrize(param, 'reset-'), :flag,
+                          "Reset #{param.name} to the default value"
       end
     end
 
@@ -345,8 +347,11 @@ module Kafo
       # enable/disable modules according to CLI
       config.modules.each { |mod| send("enable_#{mod.name}?") ? mod.enable : mod.disable }
 
-      # set values coming from CLI arguments
+      # set and reset values coming from CLI arguments
       params.each do |param|
+        if send("reset_#{u(with_prefix(param))}?")
+          param.unset_value
+        end
         variable_name = u(with_prefix(param))
         variable_name += '_list' if param.multivalued?
         cli_value     = instance_variable_get("@#{variable_name}")

--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -26,6 +26,11 @@ module Kafo
       @value     = value == 'UNDEF' ? nil : value
     end
 
+    def unset_value
+      @value_set = false
+      @value     = nil
+    end
+
     def dump_default
       default
     end
@@ -40,7 +45,7 @@ module Kafo
 
     def set_default(defaults)
       if default == 'UNSET'
-        self.value = nil
+        self.default = nil
       else
         if defaults.has_key?(default)
           value = defaults[default]
@@ -48,21 +53,19 @@ module Kafo
             when :undef
               # value can be set to :undef if value is not defined
               # (e.g. puppetmaster = $::puppetmaster which is not defined yet)
-              self.value = nil
+              self.default = nil
             when :undefined
               # in puppet 2.7 :undefined means that it's param which value is
               # not set by another parameter (e.g. foreman_group = 'something')
               # which means, default is sensible unlike dumped default
               # newer puppet has default dump in format 'value' => 'value' so
               # it's handled correctly by else branch
-              self.value = self.default
             else
-              self.value = value
+              self.default = value
           end
-          # if we don't have default value from dump (can happen for modules added from hooks)
-          # we fallback to their own default values which must be sensible
-        else
-          self.value = self.default
+          # if we don't have default value from dump (can happen for modules added from hooks,
+          # or without using a params class), the existing default value from the manifest will
+          # be used. On calling #value, the default will be returned if no overriding value is set.
         end
       end
     end

--- a/lib/kafo/string_helper.rb
+++ b/lib/kafo/string_helper.rb
@@ -18,8 +18,8 @@ module Kafo
       "#{prefix}#{d(param.name)}"
     end
 
-    def parametrize(param)
-      "--#{with_prefix(param)}"
+    def parametrize(param, prefix='')
+      "--#{prefix}#{with_prefix(param)}"
     end
   end
 end

--- a/lib/kafo/wizard.rb
+++ b/lib/kafo/wizard.rb
@@ -87,6 +87,7 @@ END
             others.each do |group|
               menu.choice("Configure #{group.formatted_name}") { configure_group(group) }
             end
+            menu.choice("Reset a parameter to its default value") { reset_module_params(mod) }
           end
           menu.choice("Back to main menu") { go_back = true }
         end
@@ -151,6 +152,26 @@ END
 
     def turn_module(mod)
       agree("Enable #{mod.name} module? (y/n) ") ? mod.enable : mod.disable
+    end
+
+    def reset_module_params(mod)
+      go_back = false
+      until go_back
+        say "\n" + HighLine.color("Resetting parameters of module #{mod.name}", :headline)
+        choose do |menu|
+          mod.params.each do |param|
+            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value.to_s, :info)}, default value: #{HighLine.color(param.default.to_s, :info)}" do
+              reset(param)
+            end if param.visible?(@kafo.params)
+          end
+          menu.choice("Back to parent menu") { go_back = true }
+        end
+      end
+    end
+
+    def reset(param)
+      param.unset_value
+      say "\n" + HighLine.color("Value for #{param.name} reset to default", :important)
     end
 
     def setup_terminal

--- a/test/kafo/help_builders/advanced_test.rb
+++ b/test/kafo/help_builders/advanced_test.rb
@@ -23,8 +23,11 @@ module Kafo
       let(:clamp_definitions) do
         [
             OpenStruct.new(:help => ['--puppet-version', 'version parameter']),
+            OpenStruct.new(:help => ['--reset-puppet-version', 'reset puppet-version to default value']),
             OpenStruct.new(:help => ['--puppet-server', 'enable puppetmaster server']),
+            OpenStruct.new(:help => ['--reset-puppet-server', 'reset puppet-server to default value']),
             OpenStruct.new(:help => ['--puppet-port', 'puppetmaster port']),
+            OpenStruct.new(:help => ['--reset-puppet-port', 'reset puppet-port to default value']),
             OpenStruct.new(:help => ['--no-colors', 'app wide argument, not a parameter']),
         ]
       end
@@ -47,6 +50,8 @@ module Kafo
           specify { output.must_include '== Basic' }
           specify { output.must_include '--puppet-version' }
           specify { output.must_include 'version parameter' }
+          specify { output.must_include '--reset-puppet-version' }
+          specify { output.must_include 'reset puppet-version' }
           specify { output.must_include '== Advanced' }
           specify { output.must_include '--puppet-server' }
           specify { output.must_include 'enable puppetmaster server' }
@@ -55,7 +60,7 @@ module Kafo
         end
 
         describe "single group output" do
-          before { builder.add_list('Options', clamp_definitions[2..3]) }
+          before { builder.add_list('Options', clamp_definitions[4..6]) }
           let(:output) { stdout.rewind; stdout.read }
           specify { output.must_include 'Options' }
           specify { output.must_include '= Generic:' }
@@ -66,10 +71,12 @@ module Kafo
           specify { output.wont_include '== Advanced' }
           specify { output.must_include '--puppet-port' }
           specify { output.must_include 'puppetmaster port' }
+          specify { output.must_include '--reset-puppet-port' }
+          specify { output.must_include 'reset puppet-port' }
         end
 
         describe "no group" do
-          before { builder.add_list('Options', clamp_definitions[3..3]) }
+          before { builder.add_list('Options', clamp_definitions[6..6]) }
           let(:output) { stdout.rewind; stdout.read }
           specify { output.must_include 'Options' }
           specify { output.must_include '= Generic:' }
@@ -79,7 +86,9 @@ module Kafo
           specify { output.wont_include '== Basic' }
           specify { output.wont_include '== Advanced' }
           specify { output.wont_include '--puppet-version' }
+          specify { output.wont_include '--reset-puppet-version' }
           specify { output.wont_include '--puppet-port' }
+          specify { output.wont_include '--reset-puppet-port' }
         end
       end
     end

--- a/test/kafo/help_builders/basic_test.rb
+++ b/test/kafo/help_builders/basic_test.rb
@@ -27,10 +27,14 @@ module Kafo
       let(:clamp_definitions) do
         [
             OpenStruct.new(:help => ['--puppet-version', 'version parameter']),
+            OpenStruct.new(:help => ['--reset-puppet-version', 'Reset version to the default value']),
             OpenStruct.new(:help => ['--puppet-server', 'enable puppetmaster server']),
+            OpenStruct.new(:help => ['--reset-puppet-server', 'Reset server to the default value']),
             OpenStruct.new(:help => ['--puppet-port', 'puppetmaster port']),
+            OpenStruct.new(:help => ['--reset-puppet-port', 'Reset port to the default value']),
             OpenStruct.new(:help => ['--no-colors', 'app wide argument, not a parameter']),
             OpenStruct.new(:help => ['--apache-port', 'apache module parameter']),
+            OpenStruct.new(:help => ['--reset-apache-port', 'Reset port to the default value']),
         ]
       end
 
@@ -50,10 +54,16 @@ module Kafo
         specify { output.must_include '= Module puppet:' }
         specify { output.must_include '--puppet-version' }
         specify { output.must_include 'version parameter' }
+        specify { output.wont_include '--reset-puppet-version' }
+        specify { output.wont_include 'reset puppet-version' }
         specify { output.wont_include '--puppet-server' }
         specify { output.wont_include 'enable puppetmaster server' }
+        specify { output.wont_include '--reset-puppet-server' }
+        specify { output.wont_include 'reset puppet-server' }
         specify { output.wont_include '--puppet-port' }
         specify { output.wont_include 'puppetmaster port' }
+        specify { output.wont_include '--reset-puppet-port' }
+        specify { output.wont_include 'reset puppet-port' }
         specify { output.wont_include 'Basic' }
         specify { output.wont_include 'Advanced' }
         specify { output.must_match /Generic.*Module apache.*Module puppet/m}

--- a/test/kafo/param_test.rb
+++ b/test/kafo/param_test.rb
@@ -159,5 +159,27 @@ module Kafo
         validation
       end
     end
+
+    describe '#set_default' do
+      let(:with_params) { param.tap { |p| p.default = 'mod::params::test' } }
+      let(:with_unset) { param.tap { |p| p.default = 'UNSET' } }
+      let(:with_value) { param.tap { |p| p.default = 42 } }
+
+      specify { with_params.tap { |p| p.set_default({}) }.default.must_equal 'mod::params::test' }
+      specify { with_params.tap { |p| p.set_default({'mod::params::test' => 42}) }.default.must_equal 42 }
+      specify { with_params.tap { |p| p.set_default({'mod::params::test' => :undef}) }.default.must_be_nil }
+      specify { with_unset.tap { |p| p.set_default({}) }.default.must_be_nil }
+      specify { with_value.tap { |p| p.set_default({42 => :undefined}) }.default.must_equal 42 }
+      specify { with_value.tap { |p| p.set_default({}) }.default.must_equal 42 }
+    end
+
+    describe '#unset_value' do
+      let(:unset) { param.tap { |p| p.unset_value } }
+      specify do
+        param.default = 'def'
+        param.value = 'val'
+        unset.value.must_equal 'def'
+      end
+    end
   end
 end


### PR DESCRIPTION
Parameters can now be reset to the default value set in the manifest by
passing --reset-mod-param or by using a reset sub-menu in interactive
mode.

The behaviour of the Param class has changed to remember defaults.
Previously for a parameter whose default was $::module::params::foo,
the 'default' always remained that parameter name, Puppet was run to
fetch the value of the params class variable, then 'value' was set to
the value of the params variable.

Now 'default' is changed to the value of the params variable so we can
differentiate between the user's value and the default. When resetting
a value to the default it now goes back to the params value instead of
the params variable name.