### PR TITLE
fixes #12166 - prevent over-counting in progress bar

### DIFF
--- a/modules/kafo_configure/lib/kafo/puppet/report_wrapper.rb
+++ b/modules/kafo_configure/lib/kafo/puppet/report_wrapper.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Kafo
   module Puppet
     class ReportWrapper
@@ -7,6 +9,7 @@ module Kafo
         @transaction     = transaction
         @report          = report
         @supported       = true
+        @resources_seen  = Set.new
       end
 
       # Needed to fool Puppet's logging framework
@@ -16,8 +19,9 @@ module Kafo
 
       def add_resource_status(status, *args, &block)
         if @supported && report.respond_to?(:resource_statuses) && report.resource_statuses.is_a?(Hash)
-          if transaction.in_main_catalog && report.resource_statuses[status.resource.to_s] && transaction.is_interesting?(status.resource)
+          if transaction.in_main_catalog && report.resource_statuses[status.resource.to_s] && transaction.tracked_resources.include?(status.resource) && !@resources_seen.include?(status.resource)
             ::Puppet.info "RESOURCE #{status.resource}"
+            @resources_seen << status.resource
           end
           report.add_resource_status(status, *args, &block)
         else

--- a/modules/kafo_configure/lib/puppet/parser/functions/add_progress.rb
+++ b/modules/kafo_configure/lib/puppet/parser/functions/add_progress.rb
@@ -10,17 +10,17 @@ module Puppet::Parser::Functions
         attr_accessor :in_main_catalog
 
         def is_interesting?(resource)
-          ![:schedule, :class, :stage, :filebucket].include?(resource.to_s.split('[')[0].downcase.to_sym)
+          ![:schedule, :class, :stage, :filebucket, :anchor, :'kafo_configure::yaml_to_class'].include?(resource.to_s.split('[')[0].downcase.to_sym)
         end
 
-        def resource_count
-          catalog.vertices.select { |resource| is_interesting?(resource) }.size
+        def tracked_resources
+          @tracked_resources ||= catalog.vertices.select { |resource| is_interesting?(resource) }.map(&:to_s)
         end
 
         def evaluate_with_trigger(*args, &block)
           if catalog.version
             self.in_main_catalog = true
-            ::Puppet.info "START #{resource_count}"
+            ::Puppet.info "START #{tracked_resources.size}"
           end
           evaluate_without_trigger(*args, &block)
           self.in_main_catalog = false if catalog.version


### PR DESCRIPTION
Defined types are evaluated twice, causing two RESOURCE lines to be
printed and double-counting. A set now tracks whether a resource has
already been evaluated and prevents progress being incremented again.

Resources such as concat 2.x and recursive file (dir) resources will
use eval_generate to add more resources into the catalog during
evaluation, which isn't in the initial count. These are now ignored by
tracking which resources were initially counted and only incrementing
the progress bar when those same resources are seen during the run.

Anchor and Kafo's own yaml_to_class resources are now also ignored to
improve the accuracy of the overall resource count.