### PR TITLE
fixes #15111 - replace HighLine::String in param values

### DIFF
--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -23,6 +23,7 @@ module Kafo
 
     def value=(value)
       @value_set = true
+      value      = value.to_s if value.is_a?(::HighLine::String)  # don't persist highline extensions
       @value     = value == 'UNDEF' ? nil : value
     end
 

--- a/test/kafo/param_test.rb
+++ b/test/kafo/param_test.rb
@@ -181,5 +181,14 @@ module Kafo
         unset.value.must_equal 'def'
       end
     end
+
+    describe '#value=' do
+      specify { param.tap { |p| p.value = 'foo' }.value.must_equal 'foo' }
+      specify { param.tap { |p| p.value = 'foo' }.value_set.must_equal true }
+      specify { param.tap { |p| p.value = 'UNDEF' }.value.must_be_nil }
+      specify { param.tap { |p| p.value = 'UNDEF' }.value_set.must_equal true }
+      specify { param.tap { |p| p.value = ::HighLine::String('foo') }.value.must_equal 'foo' }
+      specify { param.tap { |p| p.value = ::HighLine::String('foo') }.value.class.must_equal ::String }
+    end
   end
 end


### PR DESCRIPTION
By filtering these classes in the param setter, it's fixed for both the
wizard and users with persisted answers as the answers file is loaded
through the same setter.