### PR TITLE
Fixes #15322 - reload configuration prior migrations execution

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -251,6 +251,7 @@ module Kafo
         migrations.store_applied
         @logger.info("#{migrations.migrations.count} migration/s were applied. Updated configuration was saved.")
       end
+      migrations.migrations.count
     end
 
     def migrations_dir


### PR DESCRIPTION
We need to reload scenario configuration after `pre_migration` hooks are finished. Otherwise the scenario migrations are run on the original config and the result replaces what hooks produced.

Second config reload is requested only when some migrations were applied  