### PR TITLE
Fixes #15382 - Improved error messages on missing scenario

### DIFF
--- a/lib/kafo/logger.rb
+++ b/lib/kafo/logger.rb
@@ -105,7 +105,7 @@ module Kafo
 
     def self.dump_buffer(buffer)
       buffer.each do |log|
-        self.loggers.each { |logger| logger.send log[0], *log[1], &log[2] }
+        self.loggers.each { |logger| logger.send log[0], *([log[1]].flatten(1)), &log[2] }
       end
       buffer.clear
     end

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -91,12 +91,12 @@ module Kafo
         (available_scenarios.keys.count == 1 && available_scenarios.keys.first) ||
         select_scenario_interactively
       if scenario.nil?
-        fail_now("No installation scenario was selected, the installer can not continue.\n" \
-          "       Even --help content is dependent on selected scenario.\n" \
+        fail_now("No installation scenario was selected, the installer can not continue.\n" +
+          "       Even --help content is dependent on selected scenario.\n" +
           "       Select scenario with --scenario SCENARIO or list available scenarios with --list-scenarios.", :unknown_scenario)
       elsif !scenario_enabled?(scenario)
-        fail_now("Selected scenario is DISABLED, can not continue.\n" \
-          "       Use --list-scenarios to list available options.\n" \
+        fail_now("Selected scenario is DISABLED, can not continue.\n" +
+          "       Use --list-scenarios to list available options.\n" +
           "       You can also --enable-scenario SCENARIO to make the selected scenario available.", :scenario_error)
       end
       scenario

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -91,10 +91,13 @@ module Kafo
         (available_scenarios.keys.count == 1 && available_scenarios.keys.first) ||
         select_scenario_interactively
       if scenario.nil?
-        fail_now("Scenario was not selected, can not continue. Use --list-scenarios to list available options.", :unknown_scenario)
+        fail_now("No installation scenario was selected, the installer can not continue.\n" \
+          "       Even --help content is dependent on selected scenario.\n" \
+          "       Select scenario with --scenario SCENARIO or list available scenarios with --list-scenarios.", :unknown_scenario)
       elsif !scenario_enabled?(scenario)
-        fail_now("Selected scenario is DISABLED, can not continue. Use --list-scenarios to list available options." \
-	        " You can also --enable-scenario SCENARIO to make the selected scenario available.", :scenario_error)
+        fail_now("Selected scenario is DISABLED, can not continue.\n" \
+          "       Use --list-scenarios to list available options.\n" \
+          "       You can also --enable-scenario SCENARIO to make the selected scenario available.", :scenario_error)
       end
       scenario
     end


### PR DESCRIPTION
Based on users feedback I'm trying to make the error messages more clear and instructive.
The output with the patch:
```text
# foreman-installer 
ERROR: No installation scenario was selected, the installer can not continue.
       Even --help content is dependent on selected scenario.
       Select scenario with --scenario SCENARIO or list available scenarios with --list-scenarios.
```