### PR TITLE
fixes #15562 - convert undef parameter defaults to nil

### DIFF
--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -48,25 +48,23 @@ module Kafo
       if default == 'UNSET'
         self.default = nil
       else
-        if defaults.has_key?(default)
-          value = defaults[default]
-          case value
-            when :undef
-              # value can be set to :undef if value is not defined
-              # (e.g. puppetmaster = $::puppetmaster which is not defined yet)
-              self.default = nil
-            when :undefined
-              # in puppet 2.7 :undefined means that it's param which value is
-              # not set by another parameter (e.g. foreman_group = 'something')
-              # which means, default is sensible unlike dumped default
-              # newer puppet has default dump in format 'value' => 'value' so
-              # it's handled correctly by else branch
-            else
-              self.default = value
-          end
-          # if we don't have default value from dump (can happen for modules added from hooks,
-          # or without using a params class), the existing default value from the manifest will
-          # be used. On calling #value, the default will be returned if no overriding value is set.
+        # if we don't have default value from dump (can happen for modules added from hooks,
+        # or without using a params class), the existing default value from the manifest will
+        # be used. On calling #value, the default will be returned if no overriding value is set.
+        value = defaults.has_key?(default) ? defaults[default] : default
+        case value
+          when :undef
+            # value can be set to :undef if value is not defined
+            # (e.g. puppetmaster = $::puppetmaster which is not defined yet)
+            self.default = nil
+          when :undefined
+            # in puppet 2.7 :undefined means that it's param which value is
+            # not set by another parameter (e.g. foreman_group = 'something')
+            # which means, default is sensible unlike dumped default
+            # newer puppet has default dump in format 'value' => 'value' so
+            # it's handled correctly by else branch
+          else
+            self.default = value
         end
       end
     end

--- a/test/kafo/param_test.rb
+++ b/test/kafo/param_test.rb
@@ -162,12 +162,14 @@ module Kafo
 
     describe '#set_default' do
       let(:with_params) { param.tap { |p| p.default = 'mod::params::test' } }
+      let(:with_undef) { param.tap { |p| p.default = :undef } }
       let(:with_unset) { param.tap { |p| p.default = 'UNSET' } }
       let(:with_value) { param.tap { |p| p.default = 42 } }
 
       specify { with_params.tap { |p| p.set_default({}) }.default.must_equal 'mod::params::test' }
       specify { with_params.tap { |p| p.set_default({'mod::params::test' => 42}) }.default.must_equal 42 }
       specify { with_params.tap { |p| p.set_default({'mod::params::test' => :undef}) }.default.must_be_nil }
+      specify { with_undef.tap { |p| p.set_default({}) }.default.must_be_nil }
       specify { with_unset.tap { |p| p.set_default({}) }.default.must_be_nil }
       specify { with_value.tap { |p| p.set_default({42 => :undefined}) }.default.must_equal 42 }
       specify { with_value.tap { |p| p.set_default({}) }.default.must_equal 42 }


### PR DESCRIPTION
Uses the existing code to convert :undef to a nil default, but runs it
against the original parameter default for cases when a params class
isn't used.