### PR TITLE
fixes #16259 - require file containing PARSER_CACHE_VERSION

### DIFF
--- a/lib/kafo/parser_cache_reader.rb
+++ b/lib/kafo/parser_cache_reader.rb
@@ -1,3 +1,5 @@
+require 'kafo/version'
+
 module Kafo
   class ParserCacheReader
     def self.new_from_file(cache_paths)

--- a/lib/kafo/parser_cache_writer.rb
+++ b/lib/kafo/parser_cache_writer.rb
@@ -1,8 +1,10 @@
+require 'kafo/version'
+
 module Kafo
   class ParserCacheWriter
     def self.write(modules)
       {
-        :version => 1,
+        :version => PARSER_CACHE_VERSION,
         :files => Hash[modules.sort.map { |m| write_module(m) }]
       }
     end


### PR DESCRIPTION
This can't be reproduced directly from a git checkout as kafo.gemspec requires `kafo/version`, so the constant gets loaded. Either a published gem installation or removing the require from the gemspec will show up the error.