### PR TITLE
fixes #6138 - raise error if --mod-param value is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,6 +1044,7 @@ Other exit codes that can be returned:
 * '25' means that kafo could not get default values from puppet
 * '26' means that kafo could not find the specified scenario
 * '27' means that kafo found found scenario configuration error that prevents installation from continuing
+* '28' means that a value is missing for a parameter given on the command line
 * '130' user interrupt (^C)
 
 ## Running Puppet Profiling

--- a/lib/kafo/exit_handler.rb
+++ b/lib/kafo/exit_handler.rb
@@ -17,7 +17,8 @@ module Kafo
           :unknown_module => 24,
           :defaults_error => 25,
           :unset_scenario => 26,
-          :scenario_error => 27
+          :scenario_error => 27,
+          :missing_argument => 28
       }
     end
 

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -357,8 +357,16 @@ module Kafo
         variable_name = u(with_prefix(param))
         variable_name += '_list' if param.multivalued?
         cli_value     = instance_variable_get("@#{variable_name}")
+        if argument_missing?(cli_value)
+          puts "Parameter #{with_prefix(param)} is missing a value on the command line"
+          self.class.exit(:missing_argument)
+        end
         param.value   = cli_value unless cli_value.nil?
       end
+    end
+
+    def argument_missing?(value)
+      !!self.class.declared_options.find { |opt| opt.handles?(value) }
     end
 
     def store_params(file = nil)


### PR DESCRIPTION
When "--mod-param --mod-param2 foo" is given, the second parameter is
taken by clamp as the value of the first. Detect when a known option
switch is given as an argument.