### PR TITLE
fixes #17106 - change last scenario symlink to basename

### DIFF
--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -198,8 +198,8 @@ module Kafo
     def link_last_scenario(config_file)
       link_path = last_scenario_link
       if last_scenario_link
-        File.delete(last_scenario_link) if File.exist?(last_scenario_link)
-        File.symlink(config_file, last_scenario_link)
+        File.delete(last_scenario_link) if File.symlink?(last_scenario_link)
+        File.symlink(File.basename(config_file), last_scenario_link)
       end
     end
 


### PR DESCRIPTION
Prevents relative paths from the CONFIG_DIR used by ScenarioManager
leaking into the last scenario symlink target, so it is now always a
relative target to a config file in the same directory. Broken symlinks
are handled gracefully now too.
