### PR TITLE
fixes #4428 - automatically map namespaced classes to correct paths

### DIFF
--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -138,12 +138,12 @@ module Kafo
 
     # custom module directory name
     def get_dir_name
-      mapping[identifier].nil? ? name : mapping[identifier][:dir_name]
+      mapping[identifier].nil? ? default_dir_name : (mapping[identifier][:dir_name] || default_dir_name)
     end
 
     # custom manifest filename without .pp extension
     def get_manifest_name
-      mapping[identifier].nil? ? 'init' : mapping[identifier][:manifest_name]
+      mapping[identifier].nil? ? default_manifest_name : (mapping[identifier][:manifest_name] || default_manifest_name)
     end
 
     def get_class_name
@@ -155,8 +155,7 @@ module Kafo
     end
 
     def get_params_name
-      default = 'params'
-      mapping[identifier].nil? ? default : (mapping[identifier][:params_name] || default)
+      mapping[identifier].nil? ? default_params_name : (mapping[identifier][:params_name] || default_params_name)
     end
 
     def get_params_class_name
@@ -167,8 +166,20 @@ module Kafo
       "#{dir_name}/manifests/#{manifest_name}.pp"
     end
 
+    def default_dir_name
+      identifier.split('::').first
+    end
+
     def default_params_path
       "#{dir_name}/manifests/#{get_params_name}.pp"
+    end
+
+    def default_manifest_name
+      identifier.include?('::') ? identifier.split('::')[1..-1].join('/') : 'init'
+    end
+
+    def default_params_name
+      identifier.include?('::') ? (identifier.split('::')[1..-1] + ['params']).join('/') : 'params'
     end
 
     def get_name

--- a/test/kafo/puppet_module_test.rb
+++ b/test/kafo/puppet_module_test.rb
@@ -23,28 +23,39 @@ module Kafo
       specify { mod.enabled?.must_equal true }
     end
 
-    # BASIC_CONFIGURATION has mapping configured for this module
+    # Uses default Puppet autoloader locations
     let(:plugin1_mod) { PuppetModule.new 'foreman::plugin::default_hostgroup', parser }
+    # BASIC_CONFIGURATION has mapping configured for this module
     let(:plugin2_mod) { PuppetModule.new 'foreman::plugin::chef', parser }
+
+    describe "#name" do
+      specify { mod.name.must_equal 'puppet' }
+      specify { plugin1_mod.name.must_equal 'foreman_plugin_default_hostgroup' }
+      specify { plugin2_mod.name.must_equal 'foreman_plugin_chef' }
+    end
 
     describe "#dir_name" do
       specify { mod.dir_name.must_equal 'puppet' }
       specify { plugin1_mod.dir_name.must_equal 'foreman' }
+      specify { plugin2_mod.dir_name.must_equal 'custom' }
     end
 
     describe "#manifest_name" do
       specify { mod.manifest_name.must_equal 'init' }
       specify { plugin1_mod.manifest_name.must_equal 'plugin/default_hostgroup' }
+      specify { plugin2_mod.manifest_name.must_equal 'plugin/custom_chef' }
     end
 
     describe "#class_name" do
       specify { mod.class_name.must_equal 'puppet' }
       specify { plugin1_mod.class_name.must_equal 'foreman::plugin::default_hostgroup' }
+      specify { plugin2_mod.class_name.must_equal 'custom::plugin::custom_chef' }
     end
 
     describe "#manifest_path" do
       specify { mod.manifest_path.must_match %r"test/fixtures/modules/puppet/manifests/init.pp$" }
       specify { plugin1_mod.manifest_path.must_match %r"test/fixtures/modules/foreman/manifests/plugin/default_hostgroup.pp" }
+      specify { plugin2_mod.manifest_path.must_match %r"test/fixtures/modules/custom/manifests/plugin/custom_chef.pp" }
     end
 
     describe "#params_path" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,14 +31,11 @@ BASIC_CONFIGURATION = <<EOS
 :ignore_undocumented: true
 
 :mapping:
-  :foreman::plugin::default_hostgroup:
-    :dir_name: foreman
-    :manifest_name: plugin/default_hostgroup
-    :params_name: plugin/default_hostgroup/params
   :foreman::plugin::chef:
-    :dir_name: foreman
-    :manifest_name: plugin/chef
+    :dir_name: custom
+    :manifest_name: plugin/custom_chef
     :params_path: custom/plugin/chef/params.pp
+    :params_name: params
 
 :password: secret
 EOS


### PR DESCRIPTION
Changes the default locations of namespaced classes (e.g. mymod::foo) to
match the Puppet autoloader locations, assuming the first component is
the module name and classes are laid out in the regular structure. Only
for non-standard layouts would the paths/names need to be overridden,
which modern Puppet versions have reduced support for in any case.