### PR TITLE
fixes #6158 - only dump defaults for param defaults starting `$`

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -201,7 +201,7 @@ module Kafo
     def preset_defaults_from_puppet
       # set values based on default_values
       params.each do |param|
-        param.set_default(params_default_values)
+        param.set_default_from_dump(params_default_values)
       end
     end
 
@@ -296,8 +296,7 @@ module Kafo
     end
 
     def params_to_dump
-      parameters = params.select { |p| p.default != 'UNSET' }
-      parameters.map { |param| "#{param.dump_default}" }.join(',')
+      params.select(&:dump_default_needed?).map(&:dump_default).join(',')
     end
 
     def format(data)

--- a/lib/kafo/param_builder.rb
+++ b/lib/kafo/param_builder.rb
@@ -59,11 +59,11 @@ module Kafo
       else
         type = Param
       end
-      param           = type.new(@module, name, data_type)
-      param.default   = data[:values][name]
-      param.doc       = data[:docs][name]
-      param.groups    = data[:groups][name]
-      param.condition = data[:conditions][name]
+      param                  = type.new(@module, name, data_type)
+      param.manifest_default = data[:values][name]
+      param.doc              = data[:docs][name]
+      param.groups           = data[:groups][name]
+      param.condition        = data[:conditions][name]
       param
     end
 

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -13,7 +13,7 @@ module Kafo
         code.must_equal 0
         out.must_include "Usage:"
         out.must_include "kafo-configure [OPTIONS]"
-        out.must_match /--testing-version\s*some version number \(current: UNDEF\)/
+        out.must_match /--testing-version\s*some version number \(current: "1.0"\)/
         out.wont_include "--testing-db-type"
         out.wont_include "--reset-"
         out.must_include "Use --full-help to view the complete list."
@@ -27,11 +27,11 @@ module Kafo
         out.must_include "Usage:"
         out.must_include "kafo-configure [OPTIONS]"
         out.must_include "== Basic:"
-        out.must_match /--testing-version\s*some version number \(current: UNDEF\)/
-        out.must_match /--reset-testing-version\s*Reset version to the default value \(UNDEF\)/
+        out.must_match /--testing-version\s*some version number \(current: "1.0"\)/
+        out.must_match /--reset-testing-version\s*Reset version to the default value \("1.0"\)/
         out.must_include "== Advanced:"
-        out.must_match /--testing-db-type\s*can be mysql or sqlite \(current: UNDEF\)/
-        out.must_match /--reset-testing-db-type\s*Reset db_type to the default value \(UNDEF\)/
+        out.must_match /--testing-db-type\s*can be mysql or sqlite \(current: "mysql"\)/
+        out.must_match /--reset-testing-db-type\s*Reset db_type to the default value \("mysql"\)/
         out.wont_include "Use --full-help to view the complete list."
       end
     end

--- a/test/kafo/puppet_module_test.rb
+++ b/test/kafo/puppet_module_test.rb
@@ -229,7 +229,7 @@ module Kafo
       specify { keys.wont_include 'documented' }
 
       specify { params_hash['version'].must_equal '1.0' }
-      specify { params_hash['undef'].must_equal :undef }
+      specify { params_hash['undef'].must_equal nil }
       # does not work with puppet 4 which support native types
       next if Gem::Specification.find_all_by_name('puppet').sort_by(&:version).last.version >= Gem::Version.new('4.0.0')
       specify { params_hash['typed'].must_equal true }


### PR DESCRIPTION
Refactors how defaults from the manifest and the defaults dump are
stored, keeping them in separate variables and expecting any params
with other variables as the default to have `$` prefixes.

Only params with a `$` default prefix will be dumped, so any other
default string values will not be dumped and are persisted correctly.

---

Needs https://github.com/theforeman/kafo_parsers/pull/31, I can increase the min kafo_parsers version in the gemspec if/when that's released.