### PR TITLE
fixes #15903 - show current vs default values in help output

### DIFF
--- a/lib/kafo/help_builders/basic.rb
+++ b/lib/kafo/help_builders/basic.rb
@@ -15,7 +15,7 @@ module Kafo
       private
 
       def except_resets(items)
-        items.select { |i| !i.help.first.strip.start_with?('--reset-') || !i.help.last.strip.end_with?('to the default value') }
+        items.select { |i| !i.help.first.strip.start_with?('--reset-') || !i.help.last.include?('to the default value (') }
       end
     end
   end

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -320,10 +320,10 @@ module Kafo
 
       params.sort.each do |param|
         doc = param.doc.nil? ? 'UNDOCUMENTED' : param.doc.join("\n")
-        self.class.option parametrize(param), '', doc,
-                          :default => param.value, :multivalued => param.multivalued?
+        self.class.option parametrize(param), '', doc + " (current: #{param.value_to_s})",
+                          :multivalued => param.multivalued?
         self.class.option parametrize(param, 'reset-'), :flag,
-                          "Reset #{param.name} to the default value"
+                          "Reset #{param.name} to the default value (#{param.default_to_s})"
       end
     end
 

--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -46,6 +46,14 @@ module Kafo
       "#<#{self.class}:#{self.object_id} @name=#{name.inspect} @default=#{default.inspect} @value=#{value.inspect} @type=#{@type}>"
     end
 
+    def default_to_s
+      internal_value_to_s(default)
+    end
+
+    def value_to_s
+      internal_value_to_s(value)
+    end
+
     def set_default(defaults)
       if default == 'UNSET'
         self.default = nil
@@ -155,6 +163,10 @@ module Kafo
         else
           value
       end
+    end
+
+    def internal_value_to_s(value)
+      value.nil? ? 'UNDEF' : value.inspect
     end
   end
 end

--- a/lib/kafo/params/password.rb
+++ b/lib/kafo/params/password.rb
@@ -46,6 +46,15 @@ module Kafo
         @module.configuration.app[:password]
       end
 
+      def internal_value_to_s(value)
+        if value.nil?
+          super
+        elsif value.empty?
+          ''.inspect
+        else
+          'REDACTED'
+        end
+      end
     end
   end
 end

--- a/lib/kafo/wizard.rb
+++ b/lib/kafo/wizard.rb
@@ -114,7 +114,7 @@ END
     def render_params(params, menu)
       params.each do |param|
         if param.visible?(@kafo.params)
-          menu.choice "Set #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value.to_s, :info)}" do
+          menu.choice "Set #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :info)}" do
             configure(param)
           end
         end
@@ -141,13 +141,13 @@ END
     end
 
     def configure_single(param)
-      say "\ncurrent value: #{HighLine.color(param.value.to_s, :info)}"
+      say "\ncurrent value: #{HighLine.color(param.value_to_s, :info)}"
       ask("new value:")
     end
 
     def configure_multi(param)
       say HighLine.color('every line is a separate value, blank line to quit, for hash use key:value syntax', :info)
-      say "\ncurrent value: #{HighLine.color(param.value.to_s, :info)} %>"
+      say "\ncurrent value: #{HighLine.color(param.value_to_s, :info)} %>"
       ask("new value:") do |q|
         q.gather = ""
       end
@@ -164,7 +164,7 @@ END
         say "\n" + HighLine.color("Resetting parameters of module #{mod.name}", :headline)
         choose do |menu|
           mod.params.each do |param|
-            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value.to_s, :info)}, default value: #{HighLine.color(param.default.to_s, :info)}" do
+            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :info)}, default value: #{HighLine.color(param.default_to_s, :info)}" do
               reset(param)
             end if param.visible?(@kafo.params)
           end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -13,8 +13,9 @@ module Kafo
         code.must_equal 0
         out.must_include "Usage:"
         out.must_include "kafo-configure [OPTIONS]"
-        out.must_match /--testing-version\s*some version number \(default: nil\)/
+        out.must_match /--testing-version\s*some version number \(current: UNDEF\)/
         out.wont_include "--testing-db-type"
+        out.wont_include "--reset-"
         out.must_include "Use --full-help to view the complete list."
       end
     end
@@ -26,9 +27,11 @@ module Kafo
         out.must_include "Usage:"
         out.must_include "kafo-configure [OPTIONS]"
         out.must_include "== Basic:"
-        out.must_match /--testing-version\s*some version number \(default: nil\)/
+        out.must_match /--testing-version\s*some version number \(current: UNDEF\)/
+        out.must_match /--reset-testing-version\s*Reset version to the default value \(UNDEF\)/
         out.must_include "== Advanced:"
-        out.must_match /--testing-db-type\s*can be mysql or sqlite \(default: nil\)/
+        out.must_match /--testing-db-type\s*can be mysql or sqlite \(current: UNDEF\)/
+        out.must_match /--reset-testing-db-type\s*Reset db_type to the default value \(UNDEF\)/
         out.wont_include "Use --full-help to view the complete list."
       end
     end

--- a/test/kafo/help_builders/basic_test.rb
+++ b/test/kafo/help_builders/basic_test.rb
@@ -26,15 +26,15 @@ module Kafo
 
       let(:clamp_definitions) do
         [
-            OpenStruct.new(:help => ['--puppet-version', 'version parameter']),
-            OpenStruct.new(:help => ['--reset-puppet-version', 'Reset version to the default value']),
-            OpenStruct.new(:help => ['--puppet-server', 'enable puppetmaster server']),
-            OpenStruct.new(:help => ['--reset-puppet-server', 'Reset server to the default value']),
-            OpenStruct.new(:help => ['--puppet-port', 'puppetmaster port']),
-            OpenStruct.new(:help => ['--reset-puppet-port', 'Reset port to the default value']),
+            OpenStruct.new(:help => ['--puppet-version', 'version parameter (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-puppet-version', 'Reset version to the default value (default: "bar")']),
+            OpenStruct.new(:help => ['--puppet-server', 'enable puppetmaster server (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-puppet-server', 'Reset server to the default value (default: "bar")']),
+            OpenStruct.new(:help => ['--puppet-port', 'puppetmaster port (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-puppet-port', 'Reset port to the default value (default: "bar")']),
             OpenStruct.new(:help => ['--no-colors', 'app wide argument, not a parameter']),
-            OpenStruct.new(:help => ['--apache-port', 'apache module parameter']),
-            OpenStruct.new(:help => ['--reset-apache-port', 'Reset port to the default value']),
+            OpenStruct.new(:help => ['--apache-port', 'apache module parameter (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-apache-port', 'Reset port to the default value (default: "bar")']),
         ]
       end
 

--- a/test/kafo/wizard_test.rb
+++ b/test/kafo/wizard_test.rb
@@ -340,7 +340,8 @@ module Kafo
 
       describe "#reset_module_params(mod)" do
         before do
-          input.puts "Reset debug, current value: true, default value: true"
+          param = puppet_module.params.detect { |p| p.name == 'debug' }
+          input.puts "Reset debug, current value: #{param.value_to_s}, default value: #{param.default_to_s}"
           input.puts "Back to parent menu"
           input.rewind
         end


### PR DESCRIPTION
Unifies display of default/value in interactive mode with help output.