### PR TITLE
Fixes #16148 - Reword 'puppet module' to plugin

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -314,7 +314,7 @@ module Kafo
       modules.each do |mod|
         self.class.option d("--[no-]enable-#{mod.name}"),
                           :flag,
-                          "Enable '#{mod.name}' puppet module",
+                          "Enable '#{mod.name}' module",
                           :default => mod.enabled?
       end
 


### PR DESCRIPTION
When reading the enable message, it can be misleading whether we enable
a plugin or a puppet module