### PR TITLE
fixes #17396 - remove the -d short option for dont-save-answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ noop so no change will be done to your system. The default value here is set to
 false!
 
 Sometimes you may want kafo not to store answers from the current run. You can
-disable saving answer by passing a ```--dont-save-answers``` argument (or -d for short).
+disable saving answers by passing a ```--dont-save-answers``` argument.
 
 Note that running ```--noop``` implies ```--dont-save-answers```.
 

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -281,7 +281,7 @@ module Kafo
                             :default => !!config.app[:colors]
       self.class.app_option ['--color-of-background'], 'COLOR', 'Your terminal background is :bright or :dark',
                             :default => config.app[:color_of_background]
-      self.class.app_option ['-d', '--dont-save-answers'], :flag, "Skip saving answers to '#{self.class.config.answer_file}'?",
+      self.class.app_option ['--dont-save-answers'], :flag, "Skip saving answers to '#{self.class.config.answer_file}'?",
                             :default => !!config.app[:dont_save_answers]
       self.class.app_option '--ignore-undocumented', :flag, 'Ignore inconsistent parameter documentation',
                             :default => false


### PR DESCRIPTION
Users are used to passing in -d to mean debug. The -d option maps
to dont-save-answers which has led to installer confusion. This
patch removes the short form of the argument and forces the user
to use the long form.