### PR TITLE
fixes #14946 - add --[no-]parser-cache argument to force cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,8 @@ configure it in config/kafo.yaml with:
 ```
 
 The cache will be skipped if the file modification time of the manifest is
-greater than the mtime recorded in the cache.
+greater than the mtime recorded in the cache. Using `--parser-cache` will force
+the use of an outdated cache, but this should be used with caution.
 
 ## Configuring Hiera
 

--- a/bin/kafo-export-params
+++ b/bin/kafo-export-params
@@ -31,15 +31,18 @@ module Kafo
 
     option ['-o', '--output'], 'FILE', 'Output file to write parameters into', :default => '-'
 
-    option '--[no-]parser-cache', :flag, 'Enable or disable the parser cache, disable for fresh results', :default => true
+    option '--[no-]parser-cache', :flag, 'Enable or disable the parser cache, disable for fresh results'
 
     def execute
+      KafoConfigure.logger      = Logger.new(STDERR)
       c                         = Configuration.new(config, false)
-      c.app[:parser_cache_path] = nil unless parser_cache?
       KafoConfigure.config      = c
+      if KafoConfigure.config.parser_cache
+        KafoConfigure.config.parser_cache.force = true if ARGV.include?('--parser-cache')
+        KafoConfigure.config.parser_cache.force = false if ARGV.include?('--no-parser-cache')
+      end
       KafoConfigure.root_dir    = File.expand_path(c.app[:installer_dir])
       KafoConfigure.module_dirs = c.module_dirs
-      KafoConfigure.logger      = Logger.new(STDERR)
 
       if output == '-'
         file = STDOUT

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -235,6 +235,12 @@ module Kafo
     def setup_config(conf_file)
       self.class.config_file      = conf_file
       self.class.config           = Configuration.new(self.class.config_file)
+
+      if self.class.config.parser_cache
+        self.class.config.parser_cache.force = true if ARGV.include?('--parser-cache')
+        self.class.config.parser_cache.force = false if ARGV.include?('--no-parser-cache')
+      end
+
       self.class.root_dir         = self.class.config.root_dir
       self.class.check_dirs       = self.class.config.check_dirs
       self.class.module_dirs      = self.class.config.module_dirs
@@ -304,6 +310,7 @@ module Kafo
       self.class.app_option ['--force'], :flag, 'Force change of installation scenaraio'
       self.class.app_option ['--compare-scenarios'], :flag, 'Show changes between last used scenario and the scenario specified with -S or --scenario argument'
       self.class.app_option ['--migrations-only'], :flag, 'Apply migrations to a selected scenario and exit'
+      self.class.app_option ['--[no-]parser-cache'], :flag, 'Force use or bypass of Puppet module parser cache'
     end
 
     def set_options

--- a/test/acceptance/kafo_export_params_test.rb
+++ b/test/acceptance/kafo_export_params_test.rb
@@ -69,11 +69,13 @@ module Kafo
     end
 
     describe 'with parser cache' do
-      it 'writes and reads cache' do
+      before do
         generate_installer
         add_manifest
         File.open(KAFO_CONFIG, 'a') { |f| f.puts ":parser_cache_path: #{INSTALLER_HOME}/parser_cache.json" }
+      end
 
+      it 'writes and reads cache' do
         code, out, err = run_command("kafo-export-params -f parsercache -c #{KAFO_CONFIG} -o #{INSTALLER_HOME}/parser_cache.json")
         code.must_equal 0
         err.must_include 'Using Puppet module parser'
@@ -84,6 +86,27 @@ module Kafo
         err.must_include "Using #{INSTALLER_HOME}/parser_cache.json cache with parsed modules"
         out.must_include "Parameters for 'testing':"
         out.must_include "--testing-db-type"
+      end
+
+      it 'forces cache with --parser-cache' do
+        code, out, err = run_command("kafo-export-params -f parsercache -c #{KAFO_CONFIG} -o #{INSTALLER_HOME}/parser_cache.json")
+        code.must_equal 0
+        File.size?("#{INSTALLER_HOME}/parser_cache.json").wont_be_nil
+        FileUtils.touch(File.join(MANIFEST_PATH, 'init.pp'), :mtime => Time.now + 3600)
+
+        code, out, err = run_command("kafo-export-params --parser-cache -f asciidoc -c #{KAFO_CONFIG}")
+        code.must_equal 0
+        err.must_include "Parser cache for #{MANIFEST_PATH}/init.pp is outdated, forced to use it anyway"
+      end
+
+      it 'forces off cache with --no-parser-cache' do
+        code, out, err = run_command("kafo-export-params -f parsercache -c #{KAFO_CONFIG} -o #{INSTALLER_HOME}/parser_cache.json")
+        code.must_equal 0
+        File.size?("#{INSTALLER_HOME}/parser_cache.json").wont_be_nil
+
+        code, out, err = run_command("kafo-export-params --no-parser-cache -f asciidoc -c #{KAFO_CONFIG}")
+        code.must_equal 0
+        err.must_include "Skipping parser cache for #{MANIFEST_PATH}/init.pp, forced off"
       end
     end
   end

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -5,6 +5,7 @@ TMPDIR = File.expand_path('../../tmp', __FILE__)
 INSTALLER_HOME = File.join(TMPDIR, 'installer')
 KAFO_CONFIG = File.join(INSTALLER_HOME, 'config', 'installer-scenarios.d', 'default.yaml')
 KAFO_ANSWERS = File.join(INSTALLER_HOME, 'config', 'installer-scenarios.d', 'default-answers.yaml')
+MANIFEST_PATH = File.join(INSTALLER_HOME, 'modules', 'testing', 'manifests')
 
 def run_command(command, opts = {})
   opts = {:be => true, :capture => true, :dir => INSTALLER_HOME}.merge(opts)
@@ -48,9 +49,8 @@ def generate_installer
 end
 
 def add_manifest(name = 'basic')
-  manifest_path = File.join(INSTALLER_HOME, 'modules', 'testing', 'manifests')
-  FileUtils.mkdir_p manifest_path
-  FileUtils.cp File.expand_path("../../fixtures/manifests/#{name}.pp", __FILE__), File.join(manifest_path, 'init.pp')
+  FileUtils.mkdir_p MANIFEST_PATH
+  FileUtils.cp File.expand_path("../../fixtures/manifests/#{name}.pp", __FILE__), File.join(MANIFEST_PATH, 'init.pp')
   unless File.exist?(KAFO_ANSWERS) && File.read(KAFO_ANSWERS).include?('testing:')
     File.open(KAFO_ANSWERS, 'a') do |answers|
       answers.write "testing:\n  base_dir: #{INSTALLER_HOME}\n"

--- a/test/kafo/parser_cache_reader_test.rb
+++ b/test/kafo/parser_cache_reader_test.rb
@@ -47,6 +47,14 @@ module Kafo
       specify { subject.new({:files => {'test' => {:data => {:parameters => []}}}}).get('test', '/test/file.pp').must_equal(:parameters => []) }
       specify { File.stub(:mtime, 1) { subject.new({:files => {'test' => {:mtime => 1, :data => :test}}}).get('test', '/test/file.pp').must_equal(:test) } }
       specify { File.stub(:mtime, 2) { subject.new({:files => {'test' => {:mtime => 1, :data => :test}}}).get('test', '/test/file.pp').must_be_nil } }
+
+      describe "with force=true" do
+        specify { File.stub(:mtime, 2) { subject.new({:files => {'test' => {:mtime => 1, :data => :test}}}, :force => true).get('test', '/test/file.pp').must_equal(:test) } }
+      end
+
+      describe "with force=false" do
+        specify { File.stub(:mtime, 1) { subject.new({:files => {'test' => {:mtime => 1, :data => :test}}}, :force => false).get('test', '/test/file.pp').must_be_nil } }
+      end
     end
 
     describe "compatibility with writer" do


### PR DESCRIPTION
With --parser-cache, outdated cache entries will be forced if present,
even if a parser is available. With --no-parser-cache, cache entries
will be ignored even if they appear up to date (same as the existing
kafo-export-params argument).

The default behaviour with neither argument remains the same, to only
use the cache when it appears current.