### PR TITLE
fixes #17956 - load missing defaults from data in Puppet modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,40 @@ as key:value.
 When parsing the value, the first colon divides key and value. All other
 colons are ignored.
 
+## Default values
+
+Default values for parameters are read from the class definitions in the
+manifests. If values are given inline then these will be stored by Kafo as the
+initial value of the parameter (unless set in the answers file or later changed
+by the user), e.g.
+
+```puppet
+class foreman(
+  $foreman_url = 'https://example.com'
+) {
+```
+
+If the "params" pattern is used, where the default parameter values are defined
+in another class then Kafo will attempt to retrieve them by running Puppet,
+using `include` on the params class and then getting the variable value. This
+will retrieve default values set by conditionals correctly, e.g.
+
+```puppet
+class foreman(
+  $foreman_url = $::foreman::params::foreman_url,
+) inherits foreman::params {
+```
+
+```puppet
+class foreman::params {
+  $foreman_url = 'https://example.com'
+}
+```
+
+If no inline default is given in the manifest and on Puppet 4.5+, then Kafo will
+attempt to look up a default value using [data stored in the module](https://docs.puppet.com/puppet/latest/lookup_quick_module.html). This can be specified with Hiera data files (or even a data function) in the
+module under `data/`.
+
 ## Resetting an argument
 
 Existing stored parameters can be reset back to their default value from the

--- a/config/kafo.yaml.example
+++ b/config/kafo.yaml.example
@@ -36,9 +36,6 @@
 # :log_name: configure.log
 # :log_level: :info
 
-# Change if you want to debug default answers for you modules, this directory holds default answers
-# :default_values_dir: /tmp
-
 ## Advanced configuration - if not set it's ignored
 # :log_owner: root
 # :log_group: root

--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -17,6 +17,10 @@ module Kafo
       @type   = DataType.new_from_string(type)
     end
 
+    def identifier
+      @module ? "#{@module.identifier}::#{name}" : name
+    end
+
     def groups
       @groups || []
     end
@@ -37,10 +41,10 @@ module Kafo
       @value     = nil
     end
 
-    # For literal default values, only use 'manifest_default'. For variable values, use the value
-    # loaded back from the dump in 'default'.
+    # For literal default values, only use 'manifest_default'. For variable or values from a data
+    # lookup, use the value loaded back from the dump in 'default'.
     def default
-      @type.typecast(dump_default_needed? ? @default : manifest_default)
+      @type.typecast(dump_default_needed? || !@default.nil? ? @default : manifest_default)
     end
 
     def default=(default)
@@ -89,6 +93,8 @@ module Kafo
       # be used. On calling #value, the default will be returned if no overriding value is set.
       if dump_default_needed? && defaults.has_key?(manifest_default_params_variable)
         self.default = defaults[manifest_default_params_variable]
+      elsif defaults.has_key?(identifier)
+        self.default = defaults[identifier]
       end
     end
 

--- a/modules/kafo_configure/lib/puppet/functions/dump_lookups.rb
+++ b/modules/kafo_configure/lib/puppet/functions/dump_lookups.rb
@@ -1,0 +1,14 @@
+# Find values via data lookups for class parameters
+#
+# Wraps the lookup() function for data lookups of class parameters without
+# inline defaults.
+#
+Puppet::Functions.create_function(:dump_lookups) do
+  dispatch :dump_lookups do
+    param 'Array[String]', :parameters
+  end
+
+  def dump_lookups(parameters)
+    Hash[parameters.map { |param| [param, call_function('lookup', [param], 'default_value' => nil)] }]
+  end
+end

--- a/modules/kafo_configure/lib/puppet/parser/functions/dump_values.rb
+++ b/modules/kafo_configure/lib/puppet/parser/functions/dump_values.rb
@@ -1,18 +1,13 @@
 # Find default values for variables specified as args
 #
 module Puppet::Parser::Functions
-  newfunction(:dump_values) do |args|
+  newfunction(:dump_values, :type => :rvalue) do |args|
     options = []
     options<< false if Puppet::PUPPETVERSION.start_with?('2.6')
-    data = args.map do |arg|
+    data = args.flatten.map do |arg|
       found_value = lookupvar(arg, *options)
       [arg, found_value]
     end
-    data = Hash[data]
-
-    dump_dir = lookupvar('temp_dir')
-    file_name = "#{dump_dir}/default_values.yaml"
-
-    File.open(file_name, File::WRONLY|File::CREAT|File::EXCL, 0600) { |file| file.write(YAML.dump(data)) }
+    Hash[data]
   end
 end

--- a/modules/kafo_configure/lib/puppet/parser/functions/to_yaml.rb
+++ b/modules/kafo_configure/lib/puppet/parser/functions/to_yaml.rb
@@ -1,0 +1,13 @@
+# Returns the given argument as a string containing YAML, with an end of
+# document marker.
+#
+module Puppet::Parser::Functions
+  newfunction(:to_yaml, :type => :rvalue) do |args|
+    dump = if args.all? { |a| a.is_a?(Hash) }
+             args.inject({}) { |m,a| m.merge(a) }
+           else
+             args.first
+           end
+    YAML.dump(dump) + "\n...\n"
+  end
+end

--- a/modules/kafo_configure/manifests/dump_values.pp
+++ b/modules/kafo_configure/manifests/dump_values.pp
@@ -1,0 +1,21 @@
+# Outputs a YAML hash of variable to its value, for:
+#  - variables: a list of variables from params classes that have
+#               already been included
+#  - lookups: a list of variables to find through lookup()
+#
+# The result will be merged together into one hash.
+class kafo_configure::dump_values($variables, $lookups) {
+  $dumped_vars = dump_values($variables)
+
+  # Data lookups are only supported on Puppet 4 or higher, however depend on
+  # 4.5.0 which fixes PUP-6230 where missing data correctly returns the
+  # default/undef instead of an empty hash.
+  if versioncmp($::puppetversion, '4.5') >= 0 {
+    $dumped_lookups = dump_lookups($lookups)
+    $dumped = to_yaml($dumped_vars, $dumped_lookups)
+  } else {
+    $dumped = to_yaml($dumped_vars)
+  }
+
+  notice("\n${dumped}")
+}

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -1,4 +1,5 @@
 require 'acceptance/test_helper'
+require 'puppet/version'
 
 module Kafo
   describe 'kafo-configure' do
@@ -120,6 +121,21 @@ module Kafo
         code, out, err = run_command 'bin/kafo-configure -v -l debug --no-parser-cache'
         code.must_equal 0
         out.must_include "Skipping parser cache for #{MANIFEST_PATH}/init.pp, forced off"
+      end
+    end
+
+    describe 'with module data' do
+      before do
+        add_manifest('basic_module_data')
+        add_module_data
+      end
+
+      it 'must create file' do
+        skip 'Requires Puppet 4.5+ for data in modules' if Puppet::PUPPETVERSION < '4.5.0'
+        code, out, err = run_command 'bin/kafo-configure'
+        code.must_equal 0
+        File.exist?("#{INSTALLER_HOME}/testing").must_equal true
+        File.read("#{INSTALLER_HOME}/testing").must_equal '1.0'
       end
     end
   end

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -5,7 +5,8 @@ TMPDIR = File.expand_path('../../tmp', __FILE__)
 INSTALLER_HOME = File.join(TMPDIR, 'installer')
 KAFO_CONFIG = File.join(INSTALLER_HOME, 'config', 'installer-scenarios.d', 'default.yaml')
 KAFO_ANSWERS = File.join(INSTALLER_HOME, 'config', 'installer-scenarios.d', 'default-answers.yaml')
-MANIFEST_PATH = File.join(INSTALLER_HOME, 'modules', 'testing', 'manifests')
+TEST_MODULE_PATH = File.join(INSTALLER_HOME, 'modules', 'testing')
+MANIFEST_PATH = File.join(TEST_MODULE_PATH, 'manifests')
 
 def run_command(command, opts = {})
   opts = {:be => true, :capture => true, :dir => INSTALLER_HOME}.merge(opts)
@@ -56,4 +57,9 @@ def add_manifest(name = 'basic')
       answers.write "testing:\n  base_dir: #{INSTALLER_HOME}\n"
     end
   end
+end
+
+def add_module_data(name = 'basic')
+  FileUtils.mkdir_p TEST_MODULE_PATH
+  FileUtils.cp_r File.expand_path("../../fixtures/module_data/#{name}", __FILE__) + '/.', TEST_MODULE_PATH
 end

--- a/test/fixtures/manifests/basic_module_data.pp
+++ b/test/fixtures/manifests/basic_module_data.pp
@@ -1,0 +1,52 @@
+# This manifests is used for testing
+#
+# It has no value except of covering use cases that we must test.
+#
+# @param version    some version number
+# @param undef      default is undef
+# @param multiline  param with multiline
+#                   documentation
+#                   consisting of 3 lines
+# @param typed      something having its type explicitly set
+# @param multivalue list of users
+#
+# @param debug      we have advanced parameter, yay!
+#                   group:Advanced parameters
+# @param db_type    can be mysql or sqlite
+#                   group:Advanced parameters
+# @param base_dir   directory to create files in
+#                   group:Advanced parameters
+#
+# @param remote     socket or remote connection
+#                   group: Advanced parameters, MySQL
+# @param server     hostname
+#                   condition: $remote
+#                   group: Advanced parameters, MySQL
+# @param username   username
+#                   group: Advanced parameters, MySQL
+# @param pool_size  DB pool size
+#                   group: Advanced parameters, MySQL
+#
+# @param file       filename
+#                   group: Advanced parameters, Sqlite
+#
+class testing(
+  Any $version,
+  Optional[Integer] $undef,
+  Optional[String] $multiline,
+  Boolean $typed,
+  Array[String] $multivalue,
+  Boolean $debug,
+  Enum['mysql', 'sqlite'] $db_type,
+  String $base_dir,
+  Boolean $remote,
+  String $server,
+  String $username,
+  Integer $pool_size,
+  Optional[String] $file) {
+
+  file { "${base_dir}/testing":
+    ensure  => present,
+    content => $version,
+  }
+}

--- a/test/fixtures/module_data/basic/data/common.yaml
+++ b/test/fixtures/module_data/basic/data/common.yaml
@@ -1,0 +1,16 @@
+---
+testing::base_dir: ~
+testing::db_type: 'mysql'
+testing::debug: true
+testing::file: ~
+testing::multiline: ~
+testing::multivalue:
+  - 'x'
+  - 'y'
+testing::pool_size: 10
+testing::remote: true
+testing::server: 'mysql.example.com'
+testing::typed: true
+testing::undef: ~
+testing::username: 'root'
+testing::version: '1.0'

--- a/test/fixtures/module_data/basic/hiera.yaml
+++ b/test/fixtures/module_data/basic/hiera.yaml
@@ -1,0 +1,6 @@
+---
+version: 4
+datadir: data
+hierarchy:
+  - name: "common"
+    backend: yaml

--- a/test/fixtures/module_data/basic/metadata.json
+++ b/test/fixtures/module_data/basic/metadata.json
@@ -1,0 +1,13 @@
+{
+  "name": "theforeman-testing",
+  "version": "0.0.1",
+  "author": "The Foreman",
+  "license": "GPL-3.0",
+  "summary": "Testing module",
+  "source": "https://github.com/theforeman/kafo",
+  "project_page": "https://github.com/theforeman/kafo",
+  "issues_url": "http://projects.theforeman.org/projects/kafo/issues/",
+  "tags": ["kafo"],
+  "data_provider": "hiera",
+  "dependencies": []
+}

--- a/test/kafo/configuration_test.rb
+++ b/test/kafo/configuration_test.rb
@@ -93,7 +93,7 @@ module Kafo
 
     describe '#migrate_configuration' do
 
-      let(:keys) { [:log_dir, :log_name, :log_level, :no_prefix, :default_values_dir,
+      let(:keys) { [:log_dir, :log_name, :log_level, :no_prefix,
           :colors, :color_of_background, :custom, :password, :verbose_log_level] }
 
       before do

--- a/test/kafo/param_test.rb
+++ b/test/kafo/param_test.rb
@@ -9,6 +9,7 @@ module Kafo
     let(:with_undef) { param.tap { |p| p.manifest_default = :undef } }
     let(:with_unset) { param.tap { |p| p.manifest_default = 'UNSET' } }
     let(:with_value) { param.tap { |p| p.manifest_default = '42' } }
+    let(:with_module_data) { param.tap { |p| p.default = '42' } }
 
     describe "#visible?" do
       describe "without condition" do
@@ -41,6 +42,7 @@ module Kafo
       specify { with_params.default.must_be_nil }
       specify { with_params.tap { |p| p.default = 'test' }.default.must_equal 'test' }
       specify { with_value.default.must_equal '42' }
+      specify { with_module_data.default.must_equal '42' }
     end
 
     describe "#default=" do
@@ -54,6 +56,7 @@ module Kafo
       specify { with_undef.dump_default_needed?.must_equal false }
       specify { with_unset.dump_default_needed?.must_equal false }
       specify { with_value.dump_default_needed?.must_equal false }
+      specify { with_module_data.dump_default_needed?.must_equal false }
     end
 
     describe "group" do
@@ -71,6 +74,19 @@ module Kafo
         let(:group_names) { param.groups.map(&:name) }
         specify { group_names.must_include 'one' }
         specify { group_names.must_include 'two' }
+      end
+    end
+
+    describe "#identifier" do
+      specify { param.identifier.must_equal 'test' }
+
+      describe "with module" do
+        let(:mod) do
+          mod = MiniTest::Mock.new
+          mod.expect(:identifier, 'examplemod')
+          mod
+        end
+        specify { param.identifier.must_equal 'examplemod::test' }
       end
     end
 
@@ -233,6 +249,7 @@ module Kafo
       specify { with_params.tap { |p| p.set_default_from_dump({'mod::params::test' => '42'}) }.default.must_equal '42' }
       specify { with_params.tap { |p| p.set_default_from_dump({'mod::params::test' => :undef}) }.default.must_be_nil }
       specify { with_value.tap { |p| p.set_default_from_dump({'42' => 'fail'}) }.default.must_equal '42' }
+      specify { param.tap { |p| p.set_default_from_dump({'test' => '42'}) }.default.must_equal '42' }
     end
 
     describe '#unset_value' do


### PR DESCRIPTION
For parameters without a default value and under Puppet 4, try calling
the lookup() function for each parameter name to retrieve any values
defined in the module data (e.g. Hiera files under data/). This allows
module authors to use the modern version of the 'params' pattern to
define complex, conditional default values.

New Puppet functions and a wrapper class merges the dumped values from
lookup() with the dump of params values, and output it via notice().

Demonstration: https://www.youtube.com/watch?v=FqAzIL8ENFg