### PR TITLE
Make hash regexp compatible with 1.8.7

### DIFF
--- a/lib/kafo/data_type.rb
+++ b/lib/kafo/data_type.rb
@@ -11,7 +11,7 @@ module Kafo
         new_from_string(type)
       else
         args = if keyword_re[2]
-                 hash_re = keyword_re[2].match(/\A\s*{(.*)}\s*\z/m)
+                 hash_re = keyword_re[2].match(/\A\s*\{(.*)\}\s*\z/m)
                  if hash_re
                    [parse_hash(hash_re[1])]
                  else


### PR DESCRIPTION
This regexp causes problems on 1.8.7:

```
(irb):2: warning: regexp has invalid interval
(irb):2: warning: regexp has `}' without escape
```