### PR TITLE
Fixes #19723 - installer fails if a line isn't utf-8 encoded

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -451,6 +451,7 @@ module Kafo
         PTY.spawn(command) do |stdin, stdout, pid|
           begin
             stdin.each do |line|
+              line = normalize_encoding(line)
               progress_log(*log_parser.parse(line))
               @progress_bar.update(line) if @progress_bar
             end
@@ -512,6 +513,16 @@ module Kafo
       ColorScheme.new(
         :background => config.app[:color_of_background],
         :colors => use_colors?).setup
+    end
+
+    private
+
+    def normalize_encoding(line)
+      if line.respond_to?(:encode) && line.respond_to?(:valid_encoding?)
+        line.valid_encoding? ? line : line.encode('UTF-16be', :invalid => :replace, :replace => '?').encode('UTF-8')
+      else  # Ruby 1.8.7, doesn't worry about invalid encodings
+        line
+      end
     end
   end
 end

--- a/lib/kafo/puppet_log_parser.rb
+++ b/lib/kafo/puppet_log_parser.rb
@@ -5,7 +5,6 @@ module Kafo
     end
 
     def parse(line)
-      line = normalize_encoding(line)
       method, message = case
                           when line =~ /^Error:(.*)/i || line =~ /^Err:(.*)/i
                             [:error, $1]
@@ -21,16 +20,6 @@ module Kafo
 
       @last_level = method
       return [method, message.chomp]
-    end
-
-    private
-
-    def normalize_encoding(line)
-      if line.respond_to?(:encode) && line.respond_to?(:valid_encoding?)
-        line.valid_encoding? ? line : line.encode('UTF-16be', :invalid => :replace, :replace => '?').encode('UTF-8')
-      else  # Ruby 1.8.7, doesn't worry about invalid encodings
-        line
-      end
     end
   end
 end

--- a/test/kafo/puppet_log_parser_test.rb
+++ b/test/kafo/puppet_log_parser_test.rb
@@ -16,7 +16,6 @@ module Kafo
         subject.parse('Debug: foo').must_equal [:debug, ' foo']
         subject.parse('bar').must_equal [:debug, 'bar']
       end
-      specify { subject.parse("Error: invalid \255 byte").must_equal [:error, RUBY_VERSION.start_with?('1.8') ? " invalid \255 byte" : ' invalid ? byte'] }
     end
   end
 end


### PR DESCRIPTION
https://github.com/theforeman/puppet-tftp/commit/b52230c23696737f3d9f206ed7fe460fb9c9b565 introduced a none UTF8 encoded line which breaks Kafo. 