### PR TITLE
Fixes #20473 - Error messages are sent to STDERR

### DIFF
--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -217,7 +217,7 @@ module Kafo
     private
 
     def fail_now(message, exit_code)
-      say "ERROR: #{message}"
+      $stderr.puts "ERROR: #{message}"
       KafoConfigure.logger.error message
       KafoConfigure.exit(exit_code)
     end

--- a/test/kafo/scenario_manager_test.rb
+++ b/test/kafo/scenario_manager_test.rb
@@ -167,16 +167,16 @@ module Kafo
       end
 
       it 'fails if disabled scenario is selected' do
-        disabled_answers = ConfigFileFactory.build_answers('disabled', {}.to_yaml)
-        disabled_scn = { :name => 'Disabled', :description => 'Disabled scenario', :answer_file => disabled_answers.path, :enabled => false }
-        scn_file = ConfigFileFactory.build('disabled', disabled_scn.to_yaml).path
+        error_text = with_captured_stderr do
+          disabled_answers = ConfigFileFactory.build_answers('disabled', {}.to_yaml)
+          disabled_scn = { :name => 'Disabled', :description => 'Disabled scenario', :answer_file => disabled_answers.path, :enabled => false }
+          scn_file = ConfigFileFactory.build('disabled', disabled_scn.to_yaml).path
 
-        manager.stub(:scenario_from_args, scn_file) do
-          must_exit_with_code(:scenario_error) { manager.select_scenario }
-          must_be_on_stdout(output, 'Selected scenario is DISABLED, can not continue.')
-          must_be_on_stdout(output, 'Use --list-scenarios to list available options.')
-          must_be_on_stdout(output, 'You can also --enable-scenario SCENARIO to make the selected scenario available.')
+          manager.stub(:scenario_from_args, scn_file) do
+            must_exit_with_code(:scenario_error) { manager.select_scenario }
+          end
         end
+        assert_match /ERROR: Selected scenario is DISABLED, can not continue/, error_text
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -221,3 +221,12 @@ end
 def fake_param(name, value)
   OpenStruct.new( { :name => name, :value => value } )
 end
+
+def with_captured_stderr
+  old_handle = $stderr
+  $stderr = StringIO.new
+  yield
+  $stderr.string
+ensure
+  $stderr = old_handle
+end


### PR DESCRIPTION
Error messages are belong to STDERR in UNIX.