### PR TITLE
Fix exit() in hook_context and a deprecation warning

### DIFF
--- a/lib/kafo/exit_handler.rb
+++ b/lib/kafo/exit_handler.rb
@@ -34,7 +34,7 @@ module Kafo
     end
 
     def translate_exit_code(code)
-      return code if code.is_a?(Fixnum)
+      return code if code.is_a?(Integer)
       if error_codes.has_key?(code)
         return error_codes[code]
       else

--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -77,7 +77,7 @@ module Kafo
     #   exit(0)
     #   exit(:manifest_error)
     def exit(code)
-      self.kafo.exit(code)
+      self.kafo.class.exit(code)
     end
 
     # You can load a custom config value that has been saved using store_custom_config


### PR DESCRIPTION
I didn't know how to write a proper test for this so I'm submitting this as is now. Pointers on how to properly write them would be appreciated.