### PR TITLE
Expand hook contexts

### DIFF
--- a/lib/kafo/base_context.rb
+++ b/lib/kafo/base_context.rb
@@ -1,0 +1,35 @@
+module Kafo
+  class BaseContext
+    def facts
+      self.class.facts
+    end
+
+    private
+
+    def self.symbolize(data)
+      case data
+      when Hash
+        Hash[data.map { |key, value| [key.to_sym, symbolize(value)] }]
+      when Array
+        data.map { |v| symbolize(v) }
+      else
+        data
+      end
+    end
+
+    def self.clear_caches
+      @facts = nil
+      @facter_path = nil
+    end
+
+    def self.facts
+      @facts ||= begin
+        symbolize(JSON.load(`#{facter_path} --json`) || {})
+      end
+    end
+
+    def self.facter_path
+      @facter_path ||= PuppetCommand.search_puppet_path('facter')
+    end
+  end
+end

--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -90,5 +90,10 @@ module Kafo
     def store_custom_config(key, value)
       self.kafo.config.set_custom(key, value)
     end
+
+    # Return the path to the current scenario
+    def scenario
+      self.kafo.class.scenario_manager.select_scenario
+    end
   end
 end

--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -1,7 +1,8 @@
 require 'kafo/data_type'
+require 'kafo/base_context'
 
 module Kafo
-  class HookContext
+  class HookContext < BaseContext
     attr_reader :kafo
 
     def self.execute(kafo, &hook)

--- a/lib/kafo/migration_context.rb
+++ b/lib/kafo/migration_context.rb
@@ -1,5 +1,7 @@
+require 'kafo/base_context'
+
 module Kafo
-  class MigrationContext
+  class MigrationContext < BaseContext
 
     attr_accessor :scenario, :answers
 
@@ -16,22 +18,6 @@ module Kafo
 
     def logger
       KafoConfigure.logger
-    end
-
-    def facts
-      self.class.facts
-    end
-
-    private
-
-    def self.facts
-      @facts ||= begin
-        YAML.load(`#{facter_path} --yaml`).inject({}) { |facts,(k,v)| facts.update(k.to_sym => v) }
-      end
-    end
-
-    def self.facter_path
-      @facter_path ||= PuppetCommand.search_puppet_path('facter')
     end
   end
 end

--- a/test/kafo/migration_context_test.rb
+++ b/test/kafo/migration_context_test.rb
@@ -4,6 +4,8 @@ module Kafo
   describe MigrationContext do
     let(:context) { MigrationContext.new({}, {}) }
 
+    before(:each) { MigrationContext.clear_caches }
+
     describe "api" do
       specify { context.respond_to?(:logger) }
       specify { context.respond_to?(:scenario) }
@@ -16,12 +18,19 @@ module Kafo
     end
 
     describe '.facts' do
-      specify { MigrationContext.stub(:`, {'foo' => 'bar'}.to_yaml) { MigrationContext.facts.must_equal(:foo => 'bar') } }
+      specify { MigrationContext.stub(:`, {'foo' => 'bar'}.to_json) { MigrationContext.facts.must_equal(:foo => 'bar') } }
+
       specify do
         PuppetCommand.stub(:search_puppet_path, Proc.new { |bin| '/opt/puppetlabs/bin/facter' if bin == 'facter' }) do
-          MigrationContext.stub(:`, Proc.new { |cmd| {'foo' => 'bar'}.to_yaml if cmd == '/opt/puppetlabs/bin/facter --yaml' }) do
-            MigrationContext.facts.must_equal(:foo => 'bar')
+          MigrationContext.stub(:`, Proc.new { |cmd| {'puppet' => 'labs'}.to_json if cmd == '/opt/puppetlabs/bin/facter --json' }) do
+            MigrationContext.facts.must_equal(:puppet => 'labs')
           end
+        end
+      end
+
+      specify do
+        MigrationContext.stub(:`, {'foo' => 'bar', 'first' => {'second' => ['value']}}.to_json) do
+          MigrationContext.facts.must_equal(:foo => 'bar', :first => {:second => ['value']})
         end
       end
     end


### PR DESCRIPTION
This moves facts to a BaseContext so it can be used both in migrations and in hooks. In addition to that the scenario is provided in the hook context.

The facter output is now JSON rather than YAML.

With this the facts are now recursively processed so we can support structered facts with symbols as well. This might be a breaking change if users are already using structured facts.