### PR TITLE
[DNM] Fixes required for Ruby 2.4

### DIFF
--- a/lib/kafo/password_manager.rb
+++ b/lib/kafo/password_manager.rb
@@ -23,10 +23,10 @@ module Kafo
     end
 
     def aes_encrypt(text, passphrase)
-      cipher = OpenSSL::Cipher::Cipher.new("aes-256-cbc")
+      cipher = OpenSSL::Cipher.new("aes-256-cbc")
       cipher.encrypt
-      cipher.key = Digest::SHA2.hexdigest(passphrase)
-      cipher.iv  = Digest::SHA2.hexdigest(passphrase + passphrase)
+      cipher.key = Digest::SHA2.hexdigest(passphrase)[0..31]
+      cipher.iv  = Digest::SHA2.hexdigest(passphrase + passphrase)[0..15]
 
       encrypted = cipher.update(text)
       encrypted << cipher.final
@@ -34,10 +34,10 @@ module Kafo
     end
 
     def aes_decrypt(text, passphrase)
-      cipher = OpenSSL::Cipher::Cipher.new("aes-256-cbc")
+      cipher = OpenSSL::Cipher.new("aes-256-cbc")
       cipher.decrypt
-      cipher.key = Digest::SHA2.hexdigest(passphrase)
-      cipher.iv  = Digest::SHA2.hexdigest(passphrase + passphrase)
+      cipher.key = Digest::SHA2.hexdigest(passphrase)[0..31]
+      cipher.iv  = Digest::SHA2.hexdigest(passphrase + passphrase)[0..15]
 
       decrypted = cipher.update(Base64.decode64(text))
       decrypted << cipher.final


### PR DESCRIPTION
when running tests locally, I encountered issues like

```
  1) Error:
Kafo::Params::Password::empty password#test_0001_generates random password:
ArgumentError: key must be 32 bytes
    /home/ares/Projekty/Zdrojaky/kafo/lib/kafo/password_manager.rb:39:in `key='
    /home/ares/Projekty/Zdrojaky/kafo/lib/kafo/password_manager.rb:39:in `aes_decrypt'
    /home/ares/Projekty/Zdrojaky/kafo/test/kafo/params/password_test.rb:11:in `decrypt'
    /home/ares/Projekty/Zdrojaky/kafo/test/kafo/params/password_test.rb:42:in `block (3 levels) in <module:Kafo>'

  2) Error:
Kafo::Params::Password::non-empty password#test_0002_is able to decrypt the value:
ArgumentError: key must be 32 bytes
    /home/ares/Projekty/Zdrojaky/kafo/lib/kafo/password_manager.rb:39:in `key='
    /home/ares/Projekty/Zdrojaky/kafo/lib/kafo/password_manager.rb:39:in `aes_decrypt'
    /home/ares/Projekty/Zdrojaky/kafo/test/kafo/params/password_test.rb:11:in `decrypt'
    /home/ares/Projekty/Zdrojaky/kafo/test/kafo/params/password_test.rb:27:in `block (3 levels) in <module:Kafo>'
```

hexdigest of sha256 returns 64 bytes (2 hex digits per 1 byte)

also this fixes deprecation warnings introduced in ruby 2.4, this would most likely break compatibility with older ruby version, so I'd keep it open for tracking purposes