### PR TITLE
Allow skipping specific checks

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -131,7 +131,7 @@ module Kafo
       end
 
       unless skip_checks_i_know_better?
-        unless SystemChecker.check
+        unless SystemChecker.check(skip_check_list)
           puts "Your system does not meet configuration criteria"
           self.class.exit(:invalid_system)
         end
@@ -308,6 +308,7 @@ module Kafo
       self.class.app_option ['-p', '--profile'], :flag, 'Run puppet in profile mode?',
                             :default => false
       self.class.app_option ['-s', '--skip-checks-i-know-better'], :flag, 'Skip all system checks', :default => false
+      self.class.app_option ['--skip-check'], 'CHECK', 'Skip system check', :multivalued => true
       self.class.app_option ['--skip-puppet-version-check'], :flag, 'Skip check for compatible Puppet versions', :default => false
       self.class.app_option ['-v', '--verbose'], :flag, 'Display log on STDOUT instead of progressbar'
       self.class.app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',

--- a/test/kafo/system_check_test.rb
+++ b/test/kafo/system_check_test.rb
@@ -7,7 +7,7 @@ module Kafo
     it "returns loads checks in order" do
       KafoConfigure.stub(:check_dirs, [PATH]) do
         expected = ["./test/fixtures/checks/pass/pass.sh", "./test/fixtures/checks/pass/this_also_passes.sh"]
-        assert_equal expected, SystemChecker.new(File.join(PATH, '*')).checkers
+        assert_equal expected, SystemChecker.new(File.join(PATH, '*'), []).checkers
       end
     end
 
@@ -25,6 +25,17 @@ module Kafo
 
       KafoConfigure.stub(:check_dirs, dirs) do
         refute SystemChecker.check
+      end
+    end
+
+    it "skips any skipped checks" do
+      dirs = [
+        './test/fixtures/checks/fail',
+        './test/fixtures/checks/pass'
+      ]
+
+      KafoConfigure.stub(:check_dirs, dirs) do
+        assert SystemChecker.check(['fail.sh'])
       end
     end
 


### PR DESCRIPTION
There is still an odd interaction where every skipped check is duplicated in `skip_check_list`. Haven't tracked it down yet.