### PR TITLE
Do not use global environmentpath

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -429,12 +429,13 @@ module Kafo
       self.class.exit_handler.register_cleanup_path(hiera.temp_dir)
 
       puppetconf = PuppetConfigurer.new(
-        'color'        => false,
-        'evaltrace'    => !!@progress_bar,
-        'hiera_config' => hiera.config_path,
-        'noop'         => !!noop?,
-        'profile'      => !!profile?,
-        'show_diff'    => true
+        'color'           => false,
+        'evaltrace'       => !!@progress_bar,
+        'hiera_config'    => hiera.config_path,
+        'noop'            => !!noop?,
+        'profile'         => !!profile?,
+        'show_diff'       => true,
+        'environmentpath' => hiera.temp_dir,
       )
       self.class.exit_handler.register_cleanup_path(puppetconf.config_path)
 


### PR DESCRIPTION
This prevents the Kafo installer from crashing if the default (global)
environment, typically /etc/puppetlabs/code/environments/production, includes a
classes array that contains classes not provided by the installer. This is often
the case when running the Kafo installer on a production Puppetmaster where
environments have been deployed.