### PR TITLE
Fixes #25058 - More robust module_enabled?

### DIFF
--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -68,7 +68,8 @@ module Kafo
     # examples:
     #   module_enabled?('example')
     def module_enabled?(module_name)
-      self.kafo.module(module_name).enabled?
+      mod = self.kafo.module(module_name)
+      !mod.nil? && mod.enabled?
     end
 
     # You can trigger installer exit by this method. You must specify exit code as a first

--- a/test/kafo/hook_context_test.rb
+++ b/test/kafo/hook_context_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 module Kafo
   describe HookContext do
-    let(:context) { HookContext.new(Object.new) }
+    let(:kafo) { Minitest::Mock.new }
+    let(:context) { HookContext.new(kafo) }
 
     describe "api" do
       specify { context.respond_to?(:logger).must_equal true }
@@ -28,6 +29,21 @@ module Kafo
             assert_equal context.scenario_data, {'foo' => 'bar'}
           end
         end
+      end
+    end
+
+    describe "#module_enabled?" do
+      specify do
+        kafo.expect :module, nil, ['unknown_module']
+        assert_equal context.module_enabled?('unknown_module'), false
+      end
+
+      specify do
+        mod = Minitest::Mock.new
+        mod.expect :nil?, false
+        mod.expect :enabled?, true
+        kafo.expect :module, mod, ['known_module']
+        assert_equal context.module_enabled?('known_module'), true
       end
     end
   end


### PR DESCRIPTION
If you have modules that are not available in every scenario. In the katello case there's katello_devel for example. Currently there's a workaround in the installer for when kafo.module returns nil but the hook itself can handle this as well. Unknown modules can be considered disabled.