### PR TITLE
[WIP] Fixes #25657 - Clear data types during configuration

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -3,6 +3,7 @@ require 'yaml'
 require 'tmpdir'
 require 'kafo/puppet_module'
 require 'kafo/color_scheme'
+require 'kafo/data_type'
 require 'kafo/data_type_parser'
 require 'kafo/puppet_configurer'
 
@@ -345,6 +346,7 @@ EOS
     end
 
     def register_data_types
+      DataType.unregister_types
       module_dirs.each do |module_dir|
         Dir[File.join(module_dir, '*', 'types', '**', '*.pp')].each do |type_file|
           DataTypeParser.new(File.read(type_file)).register

--- a/lib/kafo/data_type.rb
+++ b/lib/kafo/data_type.rb
@@ -40,6 +40,10 @@ module Kafo
       @keywords.delete(keyword) if @keywords
     end
 
+    def self.unregister_types
+      @keywords.clear
+    end
+
     def self.split_arguments(input)
       scanner = StringScanner.new(input)
       args = []


### PR DESCRIPTION
It turns out that all data types are in a global registry. When Kafo::Configure is loaded initialized, it reads the data types. This is done when the scenario has changed. That's correct, but it should clear the global registry to avoid stale entries and potential duplicates.