### PR TITLE
Move to Hiera 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,11 +160,9 @@ As you may have noticed there are several ways how to specify arguments. Here's 
 
 ## Requirements
 
-Kafo is supported with Puppet versions 3 and 4. Puppet 2 is no longer supported
-in current versions, use an older version of Kafo or update Puppet.
-
-Puppet may be installed as a gem (add it to Gemfile) or through a package,
-including official AIO packages.
+Kafo is supported with Puppet versions 4.9+, 5 and 6. Puppet may be installed
+as a gem (add it to Gemfile) or through a package, including official AIO
+packages.
 
 ## How do I report bugs or contribute?
 
@@ -1016,25 +1014,52 @@ being managed by Kafo. Set a custom Hiera config file in Kafo's config with:
 :hiera_config: /usr/share/kafo/hiera.yaml
 ```
 
-The contents of this file are as per the [hiera.yaml docs](https://docs.puppet.com/hiera/latest/configuring.html),
-but hierarchy should contain the item `kafo_answers` and the `yaml` backend
-should be enabled. Kafo will add these if they're missing.
+The contents of this file are as per the
+[hiera.yaml docs](https://docs.puppet.com/hiera/latest/configuring.html).
+Only Hiera version 5 is supported.
 
-When running Puppet, Kafo will copy the Hiera config and YAML data directory to
-a temporary location to include its data. The file `kafo_answers.yaml` will be
-generated containing _all_ default and overriden values for parameters managed
-by Kafo. This may change in the future to allow a more complex hierarchy. As an
-example, a hierarchy could be set up with:
+When running Puppet, Kafo will copy the Hiera config to a temporary location.
+Relative data directories will be changed to absolute paths. A
+`kafo_answers.yaml` file will be generated containing _all_ default and
+overriden values for parameters managed by Kafo. This may change in the future
+to allow a more complex hierarchy.
+
+The hierarchy can contain a special value with the name `Kafo Answers`. The
+exact values will be rewritten by Kafo, but it can be used to determine when
+the Kafo answers are loaded. Note the name is case sensitive. When it's
+missing, it will be added.
+
+As an example, a hierarchy could be set up with:
 
 ```yaml
-:hierarchy:
-  - kafo_answers
-  - "%{::osfamily}"
-  - common
+hierarchy:
+  - name: "Kafo Answers"
+  - name: "Other YAML hierarchy levels"
+    paths:
+      - "family/%{facts.os.family}.yaml"
+      - "common.yaml"
+```
+
+It is possible to include another file above answers:
+
+```yaml
+hierarchy:
+  - name: "Custom values"
+    datadir: "custom"
+    path: "override.yaml"
+  - name: "Kafo Answers"
+  - name: "Other YAML hierarchy levels"
+    datadir: "data"
+    paths:
+      - "family/%{facts.os.family}.yaml"
+      - "common.yaml"
 ```
 
 This would give precedence to all Kafo-managed parameter values, but for any
 others, would check for values per OS family, followed by a `common.yaml` file.
+
+[Migration from Hiera version 3](https://puppet.com/docs/puppet/4.9/hiera_migrate_v3_yaml.html)
+is documented by Puppet.
 
 ## Exit code
 

--- a/lib/kafo/hiera_configurer.rb
+++ b/lib/kafo/hiera_configurer.rb
@@ -3,6 +3,9 @@ require 'tmpdir'
 
 module Kafo
   class HieraConfigurer
+    HIERARCHY_NAME = 'Kafo Answers'
+    HIERARCHY_FILENAME = 'kafo_answers.yaml'
+
     attr_reader :temp_dir, :config_path, :data_dir, :logger
 
     def initialize(user_config_path, modules, modules_order)
@@ -13,17 +16,13 @@ module Kafo
     end
 
     def write_configs
-      @temp_dir = Dir.mktmpdir('kafo_hiera')
-      @config_path = File.join(temp_dir, 'hiera.conf')
-      @data_dir = File.join(temp_dir, 'data')
+      build_temp_dir
 
       if @user_config_path
         logger.debug("Merging existing Hiera config file from #{@user_config_path}")
         user_config = YAML.load(File.read(@user_config_path))
-        user_data_dir = user_config[:yaml][:datadir] if user_config[:yaml]
       else
         user_config = {}
-        user_data_dir = false
       end
       logger.debug("Writing Hiera config file to #{config_path}")
       File.open(config_path, 'w') do |f|
@@ -31,15 +30,10 @@ module Kafo
         f.write(format_yaml_symbols(generate_config(user_config).to_yaml))
       end
 
-      if user_data_dir
-        logger.debug("Copying Hiera data files from #{user_data_dir} to #{data_dir}")
-        FileUtils.cp_r(user_data_dir, data_dir)
-      else
-        logger.debug("Creating Hiera data files in #{data_dir}")
-        FileUtils.mkdir(data_dir)
-      end
+      logger.debug("Creating Hiera data files in #{data_dir}")
+      FileUtils.mkdir(data_dir)
 
-      File.open(File.join(data_dir, 'kafo_answers.yaml'), 'w') do |f|
+      File.open(File.join(data_dir, HIERARCHY_FILENAME), 'w') do |f|
         f.write(format_yaml_symbols(generate_data(@modules).to_yaml))
       end
     end
@@ -47,17 +41,33 @@ module Kafo
     def generate_config(config = {})
       config ||= {}
 
-      # ensure YAML is enabled
-      config[:backends] ||= []
-      config[:backends] << 'yaml' unless config[:backends].include?('yaml')
+      config['version'] = 5
 
-      # ensure kafo_answers is present and most specific
-      config[:hierarchy] ||= []
-      config[:hierarchy].unshift('kafo_answers') unless config[:hierarchy].include?('kafo_answers')
+      # ensure there are defaults
+      config['defaults'] ||= {}
+      config['defaults']['datadir'] = determine_data_dir_path(config['defaults']['datadir'])
+      config['defaults']['data_hash'] ||= 'yaml_data'
 
-      # use our copy of the data dir
-      config[:yaml] ||= {}
-      config[:yaml][:datadir] = data_dir
+      # ensure our answers file is present and has the right settings
+      config['hierarchy'] ||= []
+
+      config['hierarchy'].each do |level|
+        if level['datadir']
+          level['datadir'] = determine_data_dir_path(level['datadir'])
+        end
+      end
+
+      kafo_answers = config['hierarchy'].find { |level| level['name'] == HIERARCHY_NAME }
+      if kafo_answers
+        kafo_answers.clear
+      else
+        kafo_answers = {}
+        config['hierarchy'].unshift(kafo_answers)
+      end
+      kafo_answers['name'] = HIERARCHY_NAME
+      kafo_answers['path'] = HIERARCHY_FILENAME
+      kafo_answers['datadir'] = data_dir
+      kafo_answers['data_hash'] = 'yaml_data'
 
       config
     end
@@ -76,8 +86,26 @@ module Kafo
       (order & modules) + (modules - order)
     end
 
+    def build_temp_dir
+      @temp_dir ||= Dir.mktmpdir('kafo_hiera')
+      @config_path = File.join(temp_dir, 'hiera.conf')
+      @data_dir = File.join(temp_dir, 'data')
+    end
+
+    private
+
     def format_yaml_symbols(data)
       data.gsub('!ruby/sym ', ':')
+    end
+
+    def determine_data_dir_path(path)
+      # Relies on data_dir being absolute or having a user config
+      path ||= data_dir
+      Pathname.new(path).relative? ? File.join(original_hiera_directory, path) : path
+    end
+
+    def original_hiera_directory
+      @user_config_path ? File.dirname(@user_config_path) : nil
     end
   end
 end

--- a/modules/kafo_configure/manifests/init.pp
+++ b/modules/kafo_configure/manifests/init.pp
@@ -13,5 +13,5 @@ class kafo_configure(
     add_progress()
   }
 
-  hiera_include('classes')
+  lookup('classes', {merge => unique}).include
 }


### PR DESCRIPTION
This avoid deprecation warnings on modern Puppet versions, but does raise the minimum version to Puppet 4.9. Considering Puppet 4 is EOL, this should be acceptable.