### PR TITLE
Handle an unknown number of lines in the progress bar

### DIFF
--- a/lib/kafo/progress_bar.rb
+++ b/lib/kafo/progress_bar.rb
@@ -49,7 +49,7 @@ module Kafo
         end
       end
 
-      if (line_end = EVALTRACE_END.match(line)) && @lines < @total
+      if (line_end = EVALTRACE_END.match(line)) && @total != :unknown && @lines < @total
         if (known_resource = find_known_resource(line_end[1]))
           @resources.delete(known_resource)  # ensure it's only counted once
           @lines += 1

--- a/test/kafo/progress_bar_test.rb
+++ b/test/kafo/progress_bar_test.rb
@@ -19,5 +19,16 @@ module Kafo
       bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
       powerbar.verify
     end
+
+    it 'handles an unknown total' do
+      powerbar.expect(:show, nil, [{:msg => 'Prefetching example resources for example_type    ', :done => 0, :total => :unknown}, true])
+
+      bar.update('/Stage[main]/Example/Notify[test]: Starting to evaluate the resource')
+      bar.update('/Stage[main]/Example/Notify[test]: Evaluated in 0.5 seconds')
+      bar.update('Prefetching example resources for example_type')
+      bar.update('/Stage[main]/Example/File[/foo/bar]: Starting to evaluate the resource')
+      bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
+      powerbar.verify
+    end
   end
 end


### PR DESCRIPTION
When the progress bar fails to load, it never receives the list of resources to watch. This leads to a 0 < :unknown comparison which causes a crash. This silently ignores this and lets powerbar handle this.