### PR TITLE
Add internal Hiera variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,8 @@ Note that the hook is evaluated in HookContext object which provides a DSL:
 * ```get_custom_config``` and ```store_custom_config``` access custom config storage which persists
   among kafo runs
 * ```logger``` is also available for writing log messages
+* ```set_internal_hiera_variable```, ```get_internal_hiera_variable```,
+  ```unset_internal_hiera_variable``` can be used to set additional hiera variables.
 
 For more details, see
 [hook_context.rb](https://github.com/theforeman/kafo/blob/master/lib/kafo/hook_context.rb).

--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -29,6 +29,7 @@ module Kafo
         :custom               => {},
         :low_priority_modules => [],
         :verbose_log_level    => 'info',
+        :internal_hiera_variables => {},
         :skip_puppet_version_check => false
     }
 
@@ -88,6 +89,10 @@ module Kafo
 
     def set_custom(key, value)
       custom_storage[key.to_sym] = value
+    end
+
+    def internal_hiera_variables
+      app[:internal_hiera_variables]
     end
 
     def modules

--- a/lib/kafo/hiera_configurer.rb
+++ b/lib/kafo/hiera_configurer.rb
@@ -34,7 +34,7 @@ module Kafo
       FileUtils.mkdir(data_dir)
 
       File.open(File.join(data_dir, HIERARCHY_FILENAME), 'w') do |f|
-        f.write(format_yaml_symbols(generate_data(@modules).to_yaml))
+        f.write(format_yaml_symbols(generate_data.to_yaml))
       end
     end
 
@@ -72,9 +72,9 @@ module Kafo
       config
     end
 
-    def generate_data(modules)
+    def generate_data
       classes = []
-      data = modules.select(&:enabled?).inject({}) do |config, mod|
+      data = @modules.select(&:enabled?).inject({}) do |config, mod|
         classes << mod.class_name
         config.update(Hash[mod.params_hash.map { |k, v| ["#{mod.class_name}::#{k}", v] }])
       end

--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -93,6 +93,26 @@ module Kafo
       self.kafo.config.set_custom(key, value)
     end
 
+    # Load a Hiera variable from the internal store that has been set using
+    # set_internal_hiera_variable
+    def get_internal_hiera_variable(key)
+      self.kafo.config.internal_hiera_variables[key]
+    end
+
+    # Save any value as a Hiera variables. This is useful set variables for
+    # unmanaged modules or variables to use in the Hiera config.  These end up
+    # in the scenario configuration. Note that variables on modules that are
+    # exposed via the installer always have priority over the internal storage.
+    def set_internal_hiera_variable(key, value)
+      self.kafo.config.internal_hiera_variables[key] = value
+    end
+
+    # Clear a Hiera variable from the internal store that has been set using
+    # set_internal_hiera_variable
+    def unset_internal_hiera_variable(key)
+      self.kafo.config.internal_hiera_variables.delete(key)
+    end
+
     # Return the path to the current scenario
     def scenario_path
       self.kafo.class.scenario_manager.select_scenario

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -424,7 +424,7 @@ module Kafo
     def run_installation
       self.class.hooking.execute(:pre)
 
-      hiera = HieraConfigurer.new(config.app[:hiera_config], config.modules, config.app[:order])
+      hiera = HieraConfigurer.new(config.app[:hiera_config], config.modules, config.app[:order], config.internal_hiera_variables)
       hiera.write_configs
       self.class.exit_handler.register_cleanup_path(hiera.temp_dir)
 

--- a/test/kafo/hiera_configurer_test.rb
+++ b/test/kafo/hiera_configurer_test.rb
@@ -3,8 +3,9 @@ require 'kafo/hiera_configurer'
 
 module Kafo
   describe HieraConfigurer do
-    subject { HieraConfigurer.new(user_config_path, [], modules_order) }
+    subject { HieraConfigurer.new(user_config_path, modules, modules_order) }
     let(:user_config_path) { nil }
+    let(:modules) { [] }
     let(:modules_order) { nil }
 
     describe "#generate_config" do
@@ -66,17 +67,18 @@ module Kafo
 
     describe "#generate_data" do
       let(:puppet_module) { @@puppet_module ||= PuppetModule.new('testing', TestParser.new(BASIC_MANIFEST)).tap { |m| m.enable }.parse }
+      let(:modules) { [puppet_module] }
       specify { puppet_module.enabled?.must_equal true }
-      specify { subject.generate_data([puppet_module])['classes'].must_equal ['testing'] }
-      specify { subject.generate_data([puppet_module])['testing::version'].must_equal '1.0' }
-      specify { subject.generate_data([puppet_module]).size.must_equal (puppet_module.params.size + 1) }
+      specify { subject.generate_data['classes'].must_equal ['testing'] }
+      specify { subject.generate_data['testing::version'].must_equal '1.0' }
+      specify { subject.generate_data.size.must_equal (puppet_module.params.size + 1) }
 
       describe 'with order' do
         let(:modules_order) { ['testing', 'example'] }
         specify do
           subject.stub(:sort_modules, Proc.new { |modules, order|
             ['testing'] if modules == ['testing'] && order == modules_order
-          }) { subject.generate_data([puppet_module])['classes'].must_equal ['testing'] }
+          }) { subject.generate_data['classes'].must_equal ['testing'] }
         end
       end
     end


### PR DESCRIPTION
Internal Hiera variables allow setting additional variables. This allows setting variables for unexposed modules.

Initially I had hoped to be able to use this in hiera.yaml but you can't use lookup functions there. Probably because that would introduce recursion. Hooks can still set a collection of settings but it'd still be nicer to keep them in separate files so they can easily be updated.

This can replace the hacky setup in the mongodb migration (https://github.com/theforeman/foreman-installer/blob/4160db8eb1d8b4eb58d30fbb4cb8477db990a3e0/katello/hooks/pre/31-mongo_storage_engine.rb#L58-L61 and https://github.com/theforeman/foreman-installer/blob/4160db8eb1d8b4eb58d30fbb4cb8477db990a3e0/katello/hooks/pre/30-upgrade.rb#L60-L64).