### PR TITLE
Compatibility with clamp 1.3.1

### DIFF
--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   # better logging
   spec.add_dependency 'logging', '< 3.0.0'
   # CLI interface
-  spec.add_dependency 'clamp', '>= 0.6.2', '< 1.3.1'
+  spec.add_dependency 'clamp', '>= 1.3.1'
   # interactive mode
   spec.add_dependency 'highline', '>= 1.6.21', '< 2.0'
   # ruby progress bar

--- a/lib/kafo/help_builders/advanced.rb
+++ b/lib/kafo/help_builders/advanced.rb
@@ -6,7 +6,7 @@ module Kafo
       def add_module(name, items)
         data = by_parameter_groups(items)
         if data.keys.size > 1
-          puts module_header(name + ':')
+          line(module_header(name + ':'))
           data.keys.each do |group|
             add_list(header(2, group), data[group])
           end

--- a/lib/kafo/help_builders/base.rb
+++ b/lib/kafo/help_builders/base.rb
@@ -16,7 +16,8 @@ module Kafo
 
       def add_list(heading, items)
         if heading == 'Options'
-          puts "\n#{heading}:"
+          line()
+          line("#{heading}:")
 
           data = by_module(items)
           sorted_keys(data).each do |section|

--- a/test/kafo/help_builders/advanced_test.rb
+++ b/test/kafo/help_builders/advanced_test.rb
@@ -32,16 +32,13 @@ module Kafo
         ]
       end
 
-      let(:stdout) { StringIO.new }
       let(:builder) { HelpBuilders::Advanced.new(params) }
-
-      before { builder.instance_variable_set '@out', stdout }
 
       # note that these test do not preserve any order
       describe "#add_list" do
         describe "multi group output" do
           before { builder.add_list('Options', clamp_definitions) }
-          let(:output) { stdout.rewind; stdout.read }
+          let(:output) { builder.string }
           specify { output.must_include 'Options' }
           specify { output.must_include '= Generic:' }
           specify { output.must_include '--no-colors' }
@@ -61,7 +58,7 @@ module Kafo
 
         describe "single group output" do
           before { builder.add_list('Options', clamp_definitions[4..6]) }
-          let(:output) { stdout.rewind; stdout.read }
+          let(:output) { builder.string }
           specify { output.must_include 'Options' }
           specify { output.must_include '= Generic:' }
           specify { output.must_include '--no-colors' }
@@ -77,7 +74,7 @@ module Kafo
 
         describe "no group" do
           before { builder.add_list('Options', clamp_definitions[6..6]) }
-          let(:output) { stdout.rewind; stdout.read }
+          let(:output) { builder.string }
           specify { output.must_include 'Options' }
           specify { output.must_include '= Generic:' }
           specify { output.must_include '--no-colors' }


### PR DESCRIPTION
Not sure this is the best approach. Currently Hammer requires clamp < 1.2.0 so in packaging this would break.