### PR TITLE
Switch from ci_reporter_minitest to minitest-reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Gemfile.lock
 InstalledFiles
 _yardoc
 coverage
+jenkins/
 lib/bundler/man
 pkg
 rdoc

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,12 @@ require 'rake/testtask'
 require "bundler/gem_tasks"
 load 'tasks/jenkins.rake'
 
+Rake::TestTask.new('test:ruby') do |t|
+  t.libs << 'lib' << 'test'
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+end
+
 Rake::TestTask.new('test:unit') do |t|
   t.libs << 'lib' << 'test'
   t.test_files = FileList['test/kafo/**/*_test.rb']
@@ -27,4 +33,4 @@ end
 
 CLEAN.include 'test/tmp'
 
-task :test => ['test:unit', 'test:acceptance', 'test:puppet_modules']
+task :test => ['test:ruby', 'test:puppet_modules']

--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '>= 1.3', '< 3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'ci_reporter_minitest', '>= 1.0'
 
   spec.add_dependency 'kafo_wizards'
   spec.add_dependency 'ansi'

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -1,20 +1,8 @@
-begin
-  testtool = 'minitest'
-  require "ci/reporter/rake/#{testtool}"
-  namespace :jenkins do
-    task :unit => ["jenkins:setup:#{testtool}", 'rake:test']
+namespace :jenkins do
+  task :unit => ['jenkins:setup', 'rake:test']
 
-    namespace :setup do
-      task :pre_ci do
-        ENV["CI_CAPTURE"] = 'off'  # prevent clash with minitest's capture_subprocess_io
-        ENV["CI_REPORTS"] = 'jenkins/reports/unit/'
-        gem 'ci_reporter'
-      end
-      task :minitest  => [:pre_ci, "ci:setup:minitest"]
-      task :test_unit => [:pre_ci, "ci:setup:testunit"]
-    end
+  task :setup do
+    ENV['MINITEST_REPORTER'] ||= 'JUnitReporter'
+    ENV['MINITEST_REPORTERS_REPORTS_DIR'] ||= 'jenkins/reports/unit/'
   end
-rescue LoadError
-  # ci/reporter/rake/minitest not present, skipping this definition
 end
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,8 @@ end
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/mock'
+require "minitest/reporters"
+Minitest::Reporters.use!
 
 require 'manifest_file_factory'
 require 'config_file_factory'


### PR DESCRIPTION
The last commit to ci_reporter_minitest was in 2014 and started to generate deprecation warnings. The minitest-reporters project is maintained.