### PR TITLE
Fixes #28799: Run puppet with an empty environment

### DIFF
--- a/lib/kafo/puppet_command.rb
+++ b/lib/kafo/puppet_command.rb
@@ -38,7 +38,7 @@ module Kafo
       bin_path = (::ENV['PATH'].split(File::PATH_SEPARATOR) + ['/opt/puppetlabs/bin']).find do |path|
         File.executable?(File.join(path, bin_name))
       end
-      File.join([bin_path, bin_name].compact)
+      "env -i #{File.join([bin_path, bin_name].compact)}"
     end
 
     private


### PR DESCRIPTION
In some environments, Ruby shelling out to run puppet uses a gem
environment that cannot find the paths used by the AIO puppet. Cleaning
the environment removes these paths and allows the associated Ruby
puppet is run under to set the right paths for the given command.