### PR TITLE
Fixes #28827 - Use the correct progress_bar variable

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -429,7 +429,7 @@ module Kafo
       execution_env.store_answers
       puppetconf = execution_env.configure_puppet(
         'color'     => false,
-        'evaltrace' => !!@progressbar,
+        'evaltrace' => !!@progress_bar,
         'noop'      => !!noop?,
         'profile'   => !!profile?,
         'show_diff' => true,


### PR DESCRIPTION
29999419d8ef5288c3a87708e3cbabd896422576 introduced the execution environment but used the incorrect variable. Since Ruby doesn't fail on undefined variables, this silently failed.