### PR TITLE
Fixes #30505: Drop traceback from error message output

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -450,7 +450,8 @@ module Kafo
           begin
             stdin.each do |line|
               line = normalize_encoding(line)
-              progress_log(*log_parser.parse(line))
+              method, message = log_parser.parse(line)
+              progress_log(method, message)
               @progress_bar.update(line) if @progress_bar
             end
           rescue Errno::EIO # we reach end of input
@@ -475,6 +476,7 @@ module Kafo
     end
 
     def progress_log(method, message)
+      return if message.empty?
       @progress_bar.print_error(message + "\n") if method == :error && @progress_bar
       logger.send(method, message)
     end

--- a/lib/kafo/logger.rb
+++ b/lib/kafo/logger.rb
@@ -20,7 +20,7 @@ module Kafo
       end
     end
 
-    PATTERN = "[%5l %d %c] %m\n"
+    PATTERN = "[%5l %d] %m\n"
     Logging.color_scheme('bright',
                          :levels => {
                              :info  => :green,

--- a/lib/kafo/puppet_log_parser.rb
+++ b/lib/kafo/puppet_log_parser.rb
@@ -1,9 +1,5 @@
 module Kafo
   class PuppetLogParser
-    def initialize
-      @last_level = nil
-    end
-
     def parse(line)
       method, message = case
                           when line =~ /^Error:(.*)/i || line =~ /^Err:(.*)/i
@@ -14,11 +10,9 @@ module Kafo
                             [:info, $1]
                           when line =~ /^Debug:(.*)/i
                             [:debug, $1]
-                          else
-                            [@last_level.nil? ? :info : @last_level, line]
                         end
 
-      @last_level = method
+      message = '' if message.nil?
       return [method, message.chomp]
     end
   end

--- a/test/kafo/puppet_log_parser_test.rb
+++ b/test/kafo/puppet_log_parser_test.rb
@@ -11,10 +11,10 @@ module Kafo
       specify { _(subject.parse('Warning: foo')).must_equal [:warn, ' foo'] }
       specify { _(subject.parse('Notice: foo')).must_equal [:warn, ' foo'] }
       specify { _(subject.parse('Debug: foo')).must_equal [:debug, ' foo'] }
-      specify { _(subject.parse('unknown foo')).must_equal [:info, 'unknown foo'] }
+      specify { _(subject.parse('unknown foo')).must_equal [nil, ''] }
       specify do
         _(subject.parse('Debug: foo')).must_equal [:debug, ' foo']
-        _(subject.parse('bar')).must_equal [:debug, 'bar']
+        _(subject.parse('bar')).must_equal [nil, '']
       end
     end
   end


### PR DESCRIPTION
This is just an initial change to make things cleaner for users. Example output from dropping the traceback:

```
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-postgresql' returned 1: Error: Nothing to do
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-selinux' returned 1: Error: Nothing to do
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-service' returned 1: Error: Nothing to do
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-proxy' returned 1: Error: Nothing to do
 Execution of '/bin/yum -d 0 -e 0 -y install puppet-agent-oauth' returned 1: Error: Nothing to do
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-cli' returned 1: Error: Nothing to do
 '/opt/puppetlabs/bin/puppetserver ca setup' returned 1 instead of one of [0]
 Could not find a suitable provider for augeas
 Could not find a suitable provider for foreman_config_entry
 Could not find a suitable provider for foreman_smartproxy
Preparing installation Done                                              
  Something went wrong! Check the log for ERROR-level output
  The full log is at ./_build/foreman.log
```

This is much cleaner to read through than:

```
root@centos7 foreman-installer (develop)$ bundle exec ./bin/foreman-installer 
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-postgresql' returned 1: Error: Nothing to do
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-selinux' returned 1: Error: Nothing to do
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-service' returned 1: Error: Nothing to do
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-proxy' returned 1: Error: Nothing to do
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 Execution of '/bin/yum -d 0 -e 0 -y install puppet-agent-oauth' returned 1: Error: Nothing to do
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 Execution of '/bin/yum -d 0 -e 0 -y install foreman-cli' returned 1: Error: Nothing to do
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/execution.rb:297:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider.rb:101:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/provider/package/yum.rb:303:in `install'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:490:in `set'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/property.rb:570:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 '/opt/puppetlabs/bin/puppetserver ca setup' returned 1 instead of one of [0]
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/errors.rb:157:in `fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/type/exec.rb:183:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:241:in `sync'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:89:in `each'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/resource_harness.rb:21:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:267:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:287:in `eval_resource'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `call'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block (2 levels) in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:191:in `block in evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/graph/relationship_graph.rb:122:in `traverse'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction.rb:178:in `evaluate'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:239:in `block in apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/log.rb:161:in `with_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/transaction/report.rb:146:in `as_logging_destination'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/resource/catalog.rb:238:in `apply'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:545:in `block in thinmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:544:in `thinmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:184:in `block in apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:232:in `block in benchmark'
/opt/rh/rh-ruby25/root/usr/share/ruby/benchmark.rb:308:in `realtime'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:231:in `benchmark'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:183:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:399:in `run_internal'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:227:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/configurer.rb:210:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:343:in `apply_catalog'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:243:in `block in main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/context.rb:62:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet.rb:314:in `override'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:207:in `main'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application/apply.rb:177:in `run_command'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `block in run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util.rb:734:in `exit_on_fail'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/application.rb:382:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:143:in `run'
/root/.gem/ruby/gems/puppet-6.17.0/lib/puppet/util/command_line.rb:77:in `execute'
/root/.gem/ruby/gems/puppet-6.17.0/bin/puppet:5:in `<top (required)>'
/root/.gem/ruby/bin/puppet:23:in `load'
/root/.gem/ruby/bin/puppet:23:in `<main>'
 Could not find a suitable provider for augeas
 Could not find a suitable provider for foreman_config_entry
 Could not find a suitable provider for foreman_smartproxy
Preparing installation Done                                              
  Something went wrong! Check the log for ERROR-level output
  The full log is at ./_build/foreman.log
```