### PR TITLE
Revert "Fixes #30365: Ignore symlinks for puppet executable"

### DIFF
--- a/lib/kafo/puppet_command.rb
+++ b/lib/kafo/puppet_command.rb
@@ -38,11 +38,8 @@ module Kafo
       # Find the location of the puppet executable and use that to
       # determine the path of all executables
       bin_path = (::ENV['PATH'].split(File::PATH_SEPARATOR) + ['/opt/puppetlabs/bin']).find do |path|
-        File.executable?(File.join(path, 'puppet')) &&
-        !File.symlink?(File.join(path, 'puppet')) &&
-        File.executable?(File.join(path, bin_name))
+        File.executable?(File.join(path, 'puppet')) && File.executable?(File.join(path, bin_name))
       end
-
       File.join([bin_path, bin_name].compact)
     end
 

--- a/test/kafo/puppet_command_test.rb
+++ b/test/kafo/puppet_command_test.rb
@@ -67,25 +67,11 @@ module Kafo
         end
       end
 
-      describe "with 'puppet' in PATH as symlink" do
-        specify do
-          ::ENV.stub(:[], '/usr/bin:/usr/local/bin') do
-            File.stub(:executable?, Proc.new { |path| path == '/opt/puppetlabs/bin/puppet' }) do
-              File.stub(:symlink?, Proc.new { |path| ['/usr/bin/puppet', '/usr/local/bin/puppet'].include?(path) }) do
-                _(pc).must_equal '/opt/puppetlabs/bin/puppet'
-              end
-            end
-          end
-        end
-      end
-
       describe "with AIO 'puppet' only" do
         specify do
           ::ENV.stub(:[], '/usr/bin:/usr/local/bin') do
             File.stub(:executable?, Proc.new { |path| path == '/opt/puppetlabs/bin/puppet' }) do
-              File.stub(:symlink?, false) do
-                _(pc).must_equal '/opt/puppetlabs/bin/puppet'
-              end
+              _(pc).must_equal '/opt/puppetlabs/bin/puppet'
             end
           end
         end


### PR DESCRIPTION
This reverts commit 695ad18f7f3dccb07d93604701f68345c665b181.