### PR TITLE
Output stage to log file

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -179,6 +179,7 @@ module Kafo
           }
 EOS
 
+        ::Logging.mdc['stage'] = 'defaults'
         @logger.info 'Loading default values from puppet modules...'
         command = PuppetCommand.new(dump_manifest, [], puppetconf, self).command
         stdout, stderr, status = Open3.capture3(*PuppetCommand.format_command(command))
@@ -205,6 +206,7 @@ EOS
         end
 
         @logger.info "... finished"
+        ::Logging.mdc.delete('stage')
 
         load_yaml_from_output(stdout.split($/))
       end

--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -45,6 +45,7 @@ module Kafo
     end
 
     def execute(group)
+      ::Logging.mdc['stage'] = group
       logger.info "Executing hooks in group #{group}"
       self.hooks[group].keys.sort_by(&:to_s).each do |name|
         hook = self.hooks[group][name]
@@ -52,6 +53,7 @@ module Kafo
         logger.debug "Hook #{name} returned #{result.inspect}"
       end
       logger.info "All hooks in group #{group} finished"
+      ::Logging.mdc.delete('stage')
     end
 
     def register_pre_migrations(name, &block)

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -92,8 +92,8 @@ module Kafo
       # so we limit parsing only to app config options (because of --help and later defined params)
       parse clamp_app_arguments
       parse_app_arguments # set values from ARGS to config.app
-      Logger.setup
       self.class.set_color_scheme
+      Logger.setup
 
       self.class.hooking.execute(:init)
       set_parameters # here the params gets parsed and we need app config populated
@@ -114,9 +114,11 @@ module Kafo
 
     def run(*args)
       started_at = Time.now
+      ::Logging.mdc['stage'] = 'args'
       logger.info("Running installer with args #{args.inspect}")
       super
     ensure
+      ::Logging.mdc['stage'] = 'complete'
       logger.info("Installer finished in #{Time.now - started_at} seconds")
     end
 
@@ -410,6 +412,7 @@ module Kafo
     end
 
     def validate_all(logging = true)
+      ::Logging.mdc['stage'] = 'validation'
       logger.info 'Running validation checks'
       results = enabled_params.map do |param|
         result = param.valid?
@@ -445,6 +448,7 @@ module Kafo
       begin
         command = PuppetCommand.new('include kafo_configure', options, puppetconf).command
         log_parser = PuppetLogParser.new
+        ::Logging.mdc['stage'] = 'configure'
         PTY.spawn(*PuppetCommand.format_command(command)) do |stdin, stdout, pid|
           begin
             stdin.each do |line|


### PR DESCRIPTION
Opening a very rough draft, not to get code review but rather to get output review. Changing from outputting the name of the logger (which provides no value to the user) to the stage results in the following look and feel:

```
[ INFO 2020-08-10T11:59:08 pre_validations] Executing hooks in group pre_migrations
[ INFO 2020-08-10T11:59:08 pre_validations] All hooks in group pre_migrations finished
[ INFO 2020-08-10T11:59:08 pre_validations] Executing hooks in group boot
[ INFO 2020-08-10T11:59:08 pre_validations] All hooks in group boot finished
[ INFO 2020-08-10T11:59:08 pre_validations] Executing hooks in group init
[ INFO 2020-08-10T11:59:08 pre_validations] All hooks in group init finished
[ INFO 2020-08-10T11:59:08 pre_validations] Loading default values from puppet modules...
[ INFO 2020-08-10T11:59:08 pre_validations] ... finished
[ INFO 2020-08-10T11:59:08 pre_validations] Executing hooks in group pre_values
[ INFO 2020-08-10T11:59:08 pre_validations] All hooks in group pre_values finished
[ INFO 2020-08-10T11:59:08 pre_validations] Running installer with args [["-v"]]
[ INFO 2020-08-10T11:59:08 pre_validations] Executing hooks in group pre_validations
[ INFO 2020-08-10T11:59:10 pre_validations] All hooks in group pre_validations finished
[ INFO 2020-08-10T11:59:10 pre_validations] Running validation checks
pre_commit
[ INFO 2020-08-10T11:59:10 pre_commit] Executing hooks in group pre_commit
[ INFO 2020-08-10T11:59:10 pre_commit] All hooks in group pre_commit finished
pre
[ INFO 2020-08-10T11:59:10 pre] Executing hooks in group pre
[ INFO 2020-08-10T11:59:10 pre] Ensuring rh-postgresql12-postgresql-server, rh-redis5-redis to package state installed
[ INFO 2020-08-10T11:59:15 pre] All hooks in group pre finished
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ INFO 2020-08-10T11:59:19 configure]  Loading facts
[ WARN 2020-08-10T11:59:25 configure]  Compiled catalog for centos7.war.example.com in environment production in 3.74 seconds
[ INFO 2020-08-10T11:59:26 configure]  Applying configuration version '1597060762'
[ERROR 2020-08-10T11:59:31 configure]  Execution of '/bin/yum -d 0 -e 0 -y install foreman-postgresql' returned 1: Error: Nothing to do
[ERROR 2020-08-10T11:59:31 configure]  /Stage[main]/Foreman::Install/Package[foreman-postgresql]/ensure: change from 'purged' to 'present' failed: Execution of '/bin/yum -d 0 -e 0 -y install foreman-postgresql' returned 1: Error: Nothing to do
```

Thoughts on this? The biggest difference I can "feel" is the broken symmetry of the output.