### PR TITLE
Fixes 30637: Only display Loading facts once in the logs

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -474,6 +474,7 @@ module Kafo
     end
 
     def progress_log(method, message)
+      return if method.nil? || message.nil?
       @progress_bar.print_error(message + "\n") if method == :error && @progress_bar
       logger.send(method, message)
     end

--- a/lib/kafo/puppet_log_parser.rb
+++ b/lib/kafo/puppet_log_parser.rb
@@ -2,9 +2,16 @@ module Kafo
   class PuppetLogParser
     def initialize
       @last_level = nil
+      @loading_facts_line = false
     end
 
     def parse(line)
+      if line =~ /^Info: Loading facts/i
+        return [nil, nil] if @loading_facts_line
+
+        @loading_facts_line = true
+      end
+
       method, message = case
                           when line =~ /^Error:(.*)/i || line =~ /^Err:(.*)/i
                             [:error, $1]


### PR DESCRIPTION
Before:

```
[ INFO 2020-08-11T19:00:17 verbose] All hooks in group pre finished
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ INFO 2020-08-11T19:00:20 verbose]  Loading facts
[ WARN 2020-08-11T19:00:26 verbose]  Compiled catalog for centos7.war.example.com in environment production in 3.14 seconds
[ INFO 2020-08-11T19:00:26 verbose]  Applying configuration version '1597172423'
[ERROR 2020-08-11T19:00:28 verbose]  Execution of '/bin/yum -d 0 -e 0 -y install foreman-postgresql' returned 1: Error: Nothing to do
```

After:

```
[ INFO 2020-08-11T19:06:25 verbose] All hooks in group pre finished
[ INFO 2020-08-11T19:06:28 verbose]  Loading facts
[ WARN 2020-08-11T19:06:34 verbose]  Compiled catalog for centos7.war.example.com in environment production in 3.14 seconds
[ INFO 2020-08-11T19:06:34 verbose]  Applying configuration version '1597172791'
[ERROR 2020-08-11T19:06:36 verbose]  Execution of '/bin/yum -d 0 -e 0 -y install foreman-postgresql' returned 1: Error: Nothing to do
```