### PR TITLE
Omit Stage[main] from logs

### DIFF
--- a/lib/kafo/puppet_log_parser.rb
+++ b/lib/kafo/puppet_log_parser.rb
@@ -18,6 +18,8 @@ module Kafo
                             [@last_level.nil? ? :info : @last_level, line]
                         end
 
+      message = message.gsub('/Stage[main]', '')
+
       @last_level = method
       return [method, message.chomp.strip]
     end


### PR DESCRIPTION
The default Stage[main] in the Puppet log output provides no
additional context information. This removes it from the logs to
simplify the logs further for debugging.