### PR TITLE
Fixes #30723: Use Puppet 6.6 evaltrace for progress

### DIFF
--- a/test/kafo/progress_bar_test.rb
+++ b/test/kafo/progress_bar_test.rb
@@ -5,30 +5,49 @@ module Kafo
     let(:bar) { ProgressBar.new.tap { |pb| pb.instance_variable_set(:@bar, powerbar) } }
     let(:powerbar) { MiniTest::Mock.new }
 
-    it "calls powerbar.show" do
-      powerbar.expect(:show, nil, [{:msg => 'Notify[test]                                      ', :done => 0, :total => 2}, true])
-      powerbar.expect(:show, nil, [{:msg => 'Prefetching example resources for example_type    ', :done => 1, :total => 2}, true])
-      powerbar.expect(:show, nil, [{:msg => 'File[/foo/bar]                                    ', :done => 1, :total => 2}, true])
+    describe 'Puppet 5' do
+      it "calls powerbar.show" do
+        powerbar.expect(:show, nil, [{:msg => 'Notify[test]                                      ', :done => 0, :total => 2}, true])
+        powerbar.expect(:show, nil, [{:msg => 'Prefetching example resources for example_type    ', :done => 1, :total => 2}, true])
+        powerbar.expect(:show, nil, [{:msg => 'File[/foo/bar]                                    ', :done => 1, :total => 2}, true])
 
-      bar.update('MONITOR_RESOURCE File[/foo/bar]')
-      bar.update('MONITOR_RESOURCE Notify[test]')
-      bar.update('/Stage[main]/Example/Notify[test]: Starting to evaluate the resource')
-      bar.update('/Stage[main]/Example/Notify[test]: Evaluated in 0.5 seconds')
-      bar.update('Prefetching example resources for example_type')
-      bar.update('/Stage[main]/Example/File[/foo/bar]: Starting to evaluate the resource')
-      bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
-      powerbar.verify
+        bar.update('MONITOR_RESOURCE File[/foo/bar]')
+        bar.update('MONITOR_RESOURCE Notify[test]')
+        bar.update('/Stage[main]/Example/Notify[test]: Starting to evaluate the resource')
+        bar.update('/Stage[main]/Example/Notify[test]: Evaluated in 0.5 seconds')
+        bar.update('Prefetching example resources for example_type')
+        bar.update('/Stage[main]/Example/File[/foo/bar]: Starting to evaluate the resource')
+        bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
+        powerbar.verify
+      end
+
+      it 'handles an unknown total' do
+        powerbar.expect(:show, nil, [{:msg => 'Notify[test]                                      ', :done => 0, :total => :unknown}, true])
+        powerbar.expect(:show, nil, [{:msg => 'Prefetching example resources for example_type    ', :done => 0, :total => :unknown}, true])
+        powerbar.expect(:show, nil, [{:msg => 'File[/foo/bar]                                    ', :done => 0, :total => :unknown}, true])
+
+        bar.update('/Stage[main]/Example/Notify[test]: Starting to evaluate the resource')
+        bar.update('/Stage[main]/Example/Notify[test]: Evaluated in 0.5 seconds')
+        bar.update('Prefetching example resources for example_type')
+        bar.update('/Stage[main]/Example/File[/foo/bar]: Starting to evaluate the resource')
+        bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
+        powerbar.verify
+      end
     end
 
-    it 'handles an unknown total' do
-      powerbar.expect(:show, nil, [{:msg => 'Prefetching example resources for example_type    ', :done => 0, :total => :unknown}, true])
+    describe 'Puppet 6' do
+      it "calls powerbar.show" do
+        powerbar.expect(:show, nil, [{:msg => 'Notify[test]                                      ', :done => 0, :total => 2}, true])
+        powerbar.expect(:show, nil, [{:msg => 'Prefetching example resources for example_type    ', :done => 1, :total => 2}, true])
+        powerbar.expect(:show, nil, [{:msg => 'File[/foo/bar]                                    ', :done => 1, :total => 2}, true])
 
-      bar.update('/Stage[main]/Example/Notify[test]: Starting to evaluate the resource')
-      bar.update('/Stage[main]/Example/Notify[test]: Evaluated in 0.5 seconds')
-      bar.update('Prefetching example resources for example_type')
-      bar.update('/Stage[main]/Example/File[/foo/bar]: Starting to evaluate the resource')
-      bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
-      powerbar.verify
+        bar.update('/Stage[main]/Example/Notify[test]: Starting to evaluate the resource (1 of 2)')
+        bar.update('/Stage[main]/Example/Notify[test]: Evaluated in 0.5 seconds')
+        bar.update('Prefetching example resources for example_type')
+        bar.update('/Stage[main]/Example/File[/foo/bar]: Starting to evaluate the resource (2 of 2)')
+        bar.update('/Stage[main]/Example/File[/foo/bar]: Evaluated in 0.5 seconds')
+        powerbar.verify
+      end
     end
   end
 end


### PR DESCRIPTION
9fc5fd3c41acfdd01ffbc6c929d00987691da5d4 disabled the progress bar
monkey patch on Puppet 6. Puppet 6.6.0 started to mention the progress
when evaluating resources which can be used to update the progress bar.

Replaces https://github.com/theforeman/kafo/pull/249