### PR TITLE
Use a logger to represent each stage 

### DIFF
--- a/lib/kafo/exit_handler.rb
+++ b/lib/kafo/exit_handler.rb
@@ -27,7 +27,6 @@ module Kafo
       @exit_code = translate_exit_code(code)
       block.call if block
       logger.debug "Exit with status code: #{@exit_code} (signal was #{code})"
-      logger.dump_errors unless KafoConfigure.verbose
       cleanup
       Kernel.exit(@exit_code)
     end

--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -3,14 +3,15 @@ require 'kafo/base_context'
 
 module Kafo
   class HookContext < BaseContext
-    attr_reader :kafo
+    attr_reader :kafo, :logger
 
-    def self.execute(kafo, &hook)
-      new(kafo).instance_eval(&hook)
+    def self.execute(kafo, logger, &hook)
+      new(kafo, logger).instance_eval(&hook)
     end
 
-    def initialize(kafo)
+    def initialize(kafo, logger)
       @kafo = kafo
+      @logger = logger
     end
 
     # some of hooks won't print any message because logger is not yet configured
@@ -18,7 +19,7 @@ module Kafo
     # examples:
     #   logger.warn "this combindation of parameters is untested"
     def logger
-      self.kafo.logger
+      @logger
     end
 
     # if you want to add new app_option be sure to do as soon as possible (usually boot hook)

--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -45,13 +45,15 @@ module Kafo
     end
 
     def execute(group)
+      logger = Logger.new(group)
       logger.info "Executing hooks in group #{group}"
       self.hooks[group].keys.sort_by(&:to_s).each do |name|
         hook = self.hooks[group][name]
-        result = HookContext.execute(self.kafo, &hook)
+        result = HookContext.execute(self.kafo, logger, &hook)
         logger.debug "Hook #{name} returned #{result.inspect}"
       end
       logger.info "All hooks in group #{group} finished"
+      @group = nil
     end
 
     def register_pre_migrations(name, &block)

--- a/lib/kafo/logger.rb
+++ b/lib/kafo/logger.rb
@@ -1,31 +1,28 @@
 # encoding: UTF-8
+require 'kafo/logging'
 
 module Kafo
   class Logger
 
-    def dump_errors
-      Logging.dump_errors
+    attr_reader :logger, :name
+
+    def initialize(name = 'root')
+      @name = name
+      @logger = (name == 'root') ? Logging.root_logger : Logging.add_logger(name)
     end
 
-    def log(name, *args, &block)
+    def log(level, *args, &block)
       if Logging.buffering?
-        Logging.to_buffer(Logging.buffer, name, args, &block)
+        Logging.to_buffer(@name, level, args, &block)
       else
-        Logging.dump_buffer(Logging.buffer) if Logging.dump_needed?
-        Logging.loggers.each { |logger| logger.send name, *args, &block }
+        Logging.dump_buffer if Logging.dump_needed?
+        @logger.send(level, *args, &block)
       end
     end
 
-    %w(warn info debug).each do |name|
-      define_method(name) do |*args, &block|
-        log(name, *args, &block)
-      end
-    end
-
-    %w(fatal error).each do |name|
-      define_method(name) do |*args, &block|
-        Logging.to_buffer(Logging.error_buffer, name, *args, &block)
-        log(name, *args, &block)
+    %w(warn info debug fatal error).each do |level|
+      define_method(level) do |*args, &block|
+        log(level, *args, &block)
       end
     end
   end

--- a/lib/kafo/logging.rb
+++ b/lib/kafo/logging.rb
@@ -25,86 +25,84 @@ module Kafo
     NOCOLOR_LAYOUT = ::Logging::Layouts::Pattern.new(:pattern => PATTERN, :color_scheme => nil)
 
     class << self
-      attr_writer :loggers
+      def root_logger
+        @root_logger ||= ::Logging.logger.root
+      end
 
-      def loggers
-        @loggers ||= []
+      def setup(verbose: false)
+        level = KafoConfigure.config.app[:log_level]
+
+        setup_file_logging(
+          level,
+          KafoConfigure.config.app[:log_dir],
+          KafoConfigure.config.app[:log_owner],
+          KafoConfigure.config.app[:log_group]
+        )
+        setup_verbose(level: KafoConfigure.config.app[:verbose_log_level] || level) if verbose
+      end
+
+      def setup_file_logging(log_level, log_dir, log_owner, log_group)
+        filename = KafoConfigure.config.log_file
+
+        begin
+          FileUtils.mkdir_p(log_dir, :mode => 0750)
+        rescue Errno::EACCES
+          puts "No permissions to create log dir #{log_dir}"
+        end
+
+        begin
+          root_logger.appenders = ::Logging.appenders.rolling_file(
+            'configure',
+            :level => log_level,
+            :filename => filename,
+            :layout => NOCOLOR_LAYOUT,
+            :truncate => true
+          )
+
+          FileUtils.chown(
+            log_owner,
+            log_group,
+            filename
+          )
+        rescue ArgumentError
+          puts "File #{filename} not writeable, won't log anything to file!"
+        end
+      end
+
+      def color_layout
+        KafoConfigure.use_colors? ? COLOR_LAYOUT : NOCOLOR_LAYOUT
+      end
+
+      def add_logger(name)
+        ::Logging.logger[name]
+      end
+
+      def setup_verbose(level: :info)
+        stdout = ::Logging.appenders.stdout('verbose', :layout => color_layout, :level => level)
+        root_logger.add_appenders(stdout)
       end
 
       def buffer
         @buffer ||= []
       end
 
-      def error_buffer
-        @error_buffer ||= []
-      end
-
-      def setup
-        begin
-          FileUtils.mkdir_p(KafoConfigure.config.app[:log_dir], :mode => 0750)
-        rescue Errno::EACCES
-          puts "No permissions to create log dir #{KafoConfigure.config.app[:log_dir]}"
-        end
-
-        logger = ::Logging.logger['main']
-        filename = KafoConfigure.config.log_file
-
-        begin
-          logger.appenders = ::Logging.appenders.rolling_file(
-            'configure',
-            :filename => filename,
-            :layout   => NOCOLOR_LAYOUT,
-            :truncate => true
-          )
-
-          FileUtils.chown(
-            KafoConfigure.config.app[:log_owner],
-            KafoConfigure.config.app[:log_group],
-            filename
-          )
-        rescue ArgumentError
-          puts "File #{filename} not writeable, won't log anything to file!"
-        end
-
-        logger.level = KafoConfigure.config.app[:log_level]
-        loggers << logger
-      end
-
-      def setup_verbose
-        logger = ::Logging.logger['verbose']
-        logger.level = (KafoConfigure.config && KafoConfigure.config.app[:verbose_log_level]) || :info
-        logger.appenders = [::Logging.appenders.stdout(:layout => color_layout)]
-        loggers << logger
-      end
-
       def buffering?
-        KafoConfigure.verbose.nil? || ((KafoConfigure.verbose && !loggers.detect {|l| l.name == 'verbose'}) || loggers.empty?)
+        root_logger.appenders.empty?
       end
 
       def dump_needed?
         !buffer.empty?
       end
 
-      def to_buffer(buffer, *args)
+      def to_buffer(*args)
         buffer << args
       end
 
-      def dump_errors
-        unless error_buffer.empty?
-          loggers.each { |logger| logger.error 'Errors encountered during run:' }
-          dump_buffer(error_buffer)
+      def dump_buffer
+        @buffer.each do |log|
+          ::Logging.logger[log[0]].send(log[1], *([log[2]].flatten(2)), &log[3])
         end
-      end
-
-      def dump_buffer(buffer)
-        buffer.each do |log|
-          loggers.each { |logger| logger.send log[0], *([log[1]].flatten(1)), &log[2] }
-        end
-        buffer.clear
-      end
-
-      def color_layout
-        KafoConfigure.use_colors? ? COLOR_LAYOUT : NOCOLOR_LAYOUT
+        @buffer.clear
       end
     end
 

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -97,7 +97,10 @@ module Kafo
 
     describe 'with parser cache' do
       before do
-        File.open(KAFO_CONFIG, 'a') { |f| f.puts ":parser_cache_path: #{INSTALLER_HOME}/parser_cache.json" }
+        File.open(KAFO_CONFIG, 'a') do |f|
+          f.puts ":parser_cache_path: #{INSTALLER_HOME}/parser_cache.json"
+        end
+
         code, _, err = run_command("kafo-export-params -f parsercache -c #{KAFO_CONFIG} -o #{INSTALLER_HOME}/parser_cache.json")
         _(code).must_equal 0, err
       end

--- a/test/kafo/hook_context_test.rb
+++ b/test/kafo/hook_context_test.rb
@@ -3,7 +3,8 @@ require 'test_helper'
 module Kafo
   describe HookContext do
     let(:kafo) { Minitest::Mock.new }
-    let(:context) { HookContext.new(kafo) }
+    let(:logger) { Minitest::Mock.new }
+    let(:context) { HookContext.new(kafo, logger) }
 
     describe "api" do
       specify { assert context.respond_to?(:logger) }

--- a/test/kafo/scenario_manager_test.rb
+++ b/test/kafo/scenario_manager_test.rb
@@ -239,14 +239,15 @@ module Kafo
       end
 
       it 'prints error and exits when not forced' do
-        log_device = DummyLogger.new
-        Logging.loggers = [log_device]
         must_exit_with_code(Kafo::ExitHandler.new.error_codes[:scenario_error]) do
-          capture_subprocess_io { manager.confirm_scenario_change(new_config) }
+          manager.confirm_scenario_change(new_config)
         end
-        log_device.rewind
-        errors = log_device.error.read
-        _(errors).must_match(/You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Use --force to override. You can use --compare-scenarios to see the differences/)
+
+        KafoConfigure.stub :exit, 0 do
+          out, err = capture_subprocess_io { manager.confirm_scenario_change(new_config) }
+
+        _(out).must_match(/You are trying to replace existing installation with different scenario. This may lead to unpredictable states. Use --force to override. You can use --compare-scenarios to see the differences/)
+        end
       end
 
       it 'passes when forced (--force)' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -155,11 +155,9 @@ class Minitest::Spec
     Kafo::KafoConfigure.config   = Kafo::Configuration.new(ConfigFileFactory.build('basic', BASIC_CONFIGURATION).path)
     Kafo::KafoConfigure.root_dir = File.dirname(__FILE__)
     Kafo::KafoConfigure.exit_handler = Kafo::ExitHandler.new
-    Kafo::Logging.loggers = []
     Kafo::KafoConfigure.logger = Kafo::Logger.new
     Kafo::KafoConfigure.module_dirs = ['test/fixtures/modules']
     Kafo::Logging.buffer.clear
-    Kafo::Logging.error_buffer.clear
   end
 end
 


### PR DESCRIPTION
Requires https://github.com/theforeman/kafo/pull/273

This includes a commit that moves to using a root logger with verbose mode as an appender. This simplifies the logic and structure a lot and is part of what enables having loggers per stage.