### PR TITLE
Set "Loading facts" to be debug output

### DIFF
--- a/lib/kafo/puppet_log_parser.rb
+++ b/lib/kafo/puppet_log_parser.rb
@@ -18,6 +18,10 @@ module Kafo
                             [@last_level.nil? ? :info : @last_level, line]
                         end
 
+      if message.include?('Loading facts') && method != :error
+        method = :debug
+      end
+
       @last_level = method
       return [method, message.chomp.strip]
     end


### PR DESCRIPTION
Puppet outputs fact loading in a verbose manner with a generic message and then a specific message regarding where the facts are loading from. This can lead to useless output when using a log level above debug.


At debug level:

```
[DEBUG 2020-09-10T20:53:32 main] Loading external facts from /opt/puppetlabs/puppet/cache/facts.d
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/pulp/lib/facter/pulp_consumer_server.rb
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/pulp/lib/facter/pulp_consumer_id.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/mongodb/lib/facter/is_master.rb
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/mongodb/lib/facter/mongodb_version.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/extlib/lib/facter/extlib__puppet_config.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/redis/lib/facter/redis_server_version.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/selinux/lib/facter/selinux_python_command.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/apt/lib/facter/apt_reboot_required.rb
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/apt/lib/facter/apt_update_last_success.rb
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/apt/lib/facter/apt_updates.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/apache/lib/facter/apache_version.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/systemd/lib/facter/systemd.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/pulpcore/lib/facter/pulpcore_workers.rb
[ INFO 2020-09-10T20:53:32 main] Loading facts
[DEBUG 2020-09-10T20:53:32 main] Loading facts from /root/foreman-installer/_build/modules/foreman/lib/facter/sssd.rb
```

At info level:

```
[ INFO 2020-09-10T20:53:32 main] Loading facts
[ INFO 2020-09-10T20:53:32 main] Loading facts
[ INFO 2020-09-10T20:53:32 main] Loading facts
[ INFO 2020-09-10T20:53:32 main] Loading facts
[ INFO 2020-09-10T20:53:32 main] Loading facts
[ INFO 2020-09-10T20:53:32 main] Loading facts
[ INFO 2020-09-10T20:53:32 main] Loading facts
```

This change makes the `Loading facts` output as a debug level message and hide the clutter from info level logging.