### PR TITLE
Add notice log level 

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -17,7 +17,7 @@ module Kafo
         :log_dir              => '/var/log/kafo',
         :store_dir            => '',
         :log_name             => 'configuration.log',
-        :log_level            => 'info',
+        :log_level            => 'notice',
         :no_prefix            => false,
         :mapping              => {},
         :answer_file          => './config/answers.yaml',
@@ -29,7 +29,7 @@ module Kafo
         :custom               => {},
         :facts                => {},
         :low_priority_modules => [],
-        :verbose_log_level    => 'info',
+        :verbose_log_level    => 'notice',
         :skip_puppet_version_check => false
     }
 
@@ -179,7 +179,7 @@ module Kafo
           }
 EOS
 
-        @logger.info 'Loading default values from puppet modules...'
+        @logger.notice 'Loading default values from puppet modules...'
         command = PuppetCommand.new(dump_manifest, [], puppetconf, self).command
         stdout, stderr, status = Open3.capture3(*PuppetCommand.format_command(command))
 
@@ -204,7 +204,7 @@ EOS
           end
         end
 
-        @logger.info "... finished"
+        @logger.notice "... finished"
 
         load_yaml_from_output(stdout.split($/))
       end
@@ -309,7 +309,7 @@ EOS
         save_configuration(app)
         store(answers)
         migrations.store_applied
-        @logger.info("#{migrations.migrations.count} migration/s were applied. Updated configuration was saved.")
+        @logger.notice("#{migrations.migrations.count} migration/s were applied. Updated configuration was saved.")
       end
       migrations.migrations.count
     end

--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -46,13 +46,13 @@ module Kafo
 
     def execute(group)
       logger = Logger.new(group)
-      logger.info "Executing hooks in group #{group}"
+      logger.notice "Executing hooks in group #{group}"
       self.hooks[group].keys.sort_by(&:to_s).each do |name|
         hook = self.hooks[group][name]
         result = HookContext.execute(self.kafo, logger, &hook)
         logger.debug "Hook #{name} returned #{result.inspect}"
       end
-      logger.info "All hooks in group #{group} finished"
+      logger.notice "All hooks in group #{group} finished"
       @group = nil
     end
 

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -68,7 +68,7 @@ module Kafo
       if ARGV.include?('--migrations-only')
         verbose = (ARGV.include?('--verbose') || ARGV.include?('-v'))
         Logging.setup(verbose: verbose)
-        self.class.logger.info('Log buffers flushed')
+        self.class.logger.notice('Log buffers flushed')
         self.class.exit(0)
       end
 
@@ -81,7 +81,7 @@ module Kafo
           prev_config.run_migrations
           self.class.config.migrate_configuration(prev_config, :skip => [:log_name])
           setup_config(self.class.config_file)
-          self.class.logger.info("Due to scenario change the configuration (#{self.class.config_file}) was updated with #{scenario_manager.previous_scenario} and reloaded.")
+          self.class.logger.notice("Due to scenario change the configuration (#{self.class.config_file}) was updated with #{scenario_manager.previous_scenario} and reloaded.")
         end
       end
 
@@ -115,7 +115,7 @@ module Kafo
 
     def run(*args)
       started_at = Time.now
-      logger.info("Running installer with args #{args.inspect}")
+      logger.debug("Running installer with args #{args.inspect}")
       super
     ensure
       logger.debug("Installer finished in #{Time.now - started_at} seconds")
@@ -262,7 +262,7 @@ module Kafo
         scenario_manager = setup_scenario_manager
         self.class.scenario_manager = scenario_manager
         setup_config(self.class.config_file)
-        self.class.logger.info('Installer configuration was reloaded')
+        self.class.logger.notice('Installer configuration was reloaded')
         @config_reload_requested = false
       end
     end
@@ -309,7 +309,7 @@ module Kafo
       self.class.app_option ['--skip-puppet-version-check'], :flag, 'Skip check for compatible Puppet versions', :default => false
       self.class.app_option ['-v', '--verbose'], :flag, 'Display log on STDOUT instead of progressbar'
       self.class.app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
-                            :default => 'info'
+                            :default => 'notice'
       self.class.app_option ['-S', '--scenario'], 'SCENARIO', 'Use installation scenario'
       self.class.app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario'
       self.class.app_option ['--enable-scenario'], 'SCENARIO', 'Enable installation scenario'
@@ -409,7 +409,7 @@ module Kafo
     end
 
     def validate_all(logging = true)
-      logger.info 'Running validation checks'
+      logger.notice 'Running validation checks'
       results = enabled_params.map do |param|
         result = param.valid?
         errors = param.validation_errors.join(', ')
@@ -445,6 +445,7 @@ module Kafo
         command = PuppetCommand.new('include kafo_configure', options, puppetconf).command
         log_parser = PuppetLogParser.new
         logger = Logger.new('configure')
+        logger.notice("Starting system configuration")
 
         PTY.spawn(*PuppetCommand.format_command(command)) do |stdin, stdout, pid|
           begin
@@ -470,7 +471,7 @@ module Kafo
       end
 
       @progress_bar.close if @progress_bar
-      logger.info "Puppet has finished, bye!"
+      logger.notice "Puppet has finished, bye!"
 
       self.class.exit(exit_code) do
         self.class.hooking.execute(:post)

--- a/lib/kafo/logger.rb
+++ b/lib/kafo/logger.rb
@@ -20,7 +20,7 @@ module Kafo
       end
     end
 
-    %w(warn info debug fatal error).each do |level|
+    Logging::LOG_LEVELS.each do |level|
       define_method(level) do |*args, &block|
         log(level, *args, &block)
       end

--- a/lib/kafo/logging.rb
+++ b/lib/kafo/logging.rb
@@ -6,6 +6,12 @@ require 'logging'
 module Kafo
   class Logging
 
+    LOG_LEVELS = [:debug, :info, :notice, :warn, :error, :fatal]
+
+    if ::Logging::LEVELS.keys.map(&:to_symbol) != LOG_LEVELS
+      ::Logging.init(:debug, :info, :notice, :warn, :error, :fatal)
+    end
+
     class << self
       def root_logger
         @root_logger ||= ::Logging.logger.root
@@ -13,6 +19,7 @@ module Kafo
 
       def setup(verbose: false)
         set_color_scheme
+
         level = KafoConfigure.config.app[:log_level]
 
         setup_file_logging(
@@ -56,7 +63,8 @@ module Kafo
         ::Logging.color_scheme(
           'bright',
           :levels => {
-            :info  => :green,
+            :info => :cyan,
+            :notice => :green,
             :warn  => :yellow,
             :error => :red,
             :fatal => [:white, :on_red]
@@ -71,7 +79,7 @@ module Kafo
 
       def layout(color: false)
         ::Logging::Layouts::Pattern.new(
-          pattern: "%d [%-5l] [%c] %m\n",
+          pattern: "%d [%-6l] [%c] %m\n",
           color_scheme: color ? 'bright' : nil,
           date_pattern: '%Y-%m-%d %H:%M:%S'
         )
@@ -81,7 +89,7 @@ module Kafo
         ::Logging.logger[name]
       end
 
-      def setup_verbose(level: :info)
+      def setup_verbose(level: :notice)
         root_logger.add_appenders(
           ::Logging.appenders.stdout(
             'verbose',

--- a/lib/kafo/puppet_log_parser.rb
+++ b/lib/kafo/puppet_log_parser.rb
@@ -8,17 +8,19 @@ module Kafo
       method, message = case
                           when line =~ /^Error:(.*)/i || line =~ /^Err:(.*)/i
                             [:error, $1]
-                          when line =~ /^Warning:(.*)/i || line =~ /^Notice:(.*)/i
-                            [:warn, $1]
-                          when line =~ /^Info:(.*)/i
+                          when line =~ /^Notice:(.*)/i
                             [:info, $1]
-                          when line =~ /^Debug:(.*)/i
+                          when line =~ /^Warning:(.*)/i || line =~ /^Debug:(.*)/i || line =~ /^Info:(.*)/i
                             [:debug, $1]
                           else
                             [@last_level.nil? ? :info : @last_level, line]
                         end
 
       if message.include?('Loading facts') && method != :error
+        method = :debug
+      end
+
+      if message.include?('Applying configuration version')
         method = :debug
       end
 

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -31,7 +31,7 @@ module Kafo
     end
 
     def list_available_scenarios
-      say ::HighLine.color("Available scenarios", :info)
+      say ::HighLine.color("Available scenarios", :notice)
       available_scenarios.each do |config_file, content|
         scenario = File.basename(config_file, '.yaml')
         use = (File.expand_path(config_file) == @previous_scenario ? 'INSTALLED' : "use: --scenario #{scenario}")
@@ -111,7 +111,7 @@ module Kafo
     end
 
     def show_scenario_diff(prev_scenario, new_scenario)
-      say ::HighLine.color("Scenarios are being compared, that may take a while...", :info)
+      say ::HighLine.color("Scenarios are being compared, that may take a while...", :notice)
       prev_conf = load_and_setup_configuration(prev_scenario)
       new_conf = load_and_setup_configuration(new_scenario)
       print_scenario_diff(prev_conf, new_conf)
@@ -124,7 +124,7 @@ module Kafo
           dump_log_and_exit(0)
         else
           confirm_scenario_change(scenario)
-          @logger.info "Scenario #{scenario} was selected"
+          @logger.notice "Scenario #{scenario} was selected"
         end
       end
     end
@@ -234,9 +234,9 @@ module Kafo
       if Logging.buffering? && Logging.buffer.any?
         if !KafoConfigure.config.nil?
           Logging.setup(verbose: true)
-          @logger.info("Log was be written to #{KafoConfigure.config.log_file}")
+          @logger.notice("Log was be written to #{KafoConfigure.config.log_file}")
         end
-        @logger.info('Logs flushed')
+        @logger.notice('Logs flushed')
       end
       KafoConfigure.exit(code)
     end

--- a/lib/kafo/wizard.rb
+++ b/lib/kafo/wizard.rb
@@ -68,7 +68,7 @@ END
 
     def display_hash
       data = Hash[@config.modules.map { |mod| [mod.name, mod.enabled? ? mod.params_hash : false] }]
-      say HighLine.color(YAML.dump(data), :info)
+      say HighLine.color(YAML.dump(data), :notice)
     end
 
     def configure_module(mod)
@@ -79,7 +79,7 @@ END
           menu.prompt = 'Choose an option from the menu... '
           menu.select_by = :index
 
-          menu.choice("Enable/disable #{mod.name} module, current value: #{HighLine.color(mod.enabled?.to_s, :info)}") { turn_module(mod) }
+          menu.choice("Enable/disable #{mod.name} module, current value: #{HighLine.color(mod.enabled?.to_s, :notice)}") { turn_module(mod) }
           if mod.enabled?
             render_params(mod.primary_parameter_group.params, menu)
 
@@ -114,7 +114,7 @@ END
     def render_params(params, menu)
       params.each do |param|
         if param.visible?(@kafo.params)
-          menu.choice "Set #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :info)}" do
+          menu.choice "Set #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :notice)}" do
             configure(param)
           end
         end
@@ -141,13 +141,13 @@ END
     end
 
     def configure_single(param)
-      say "\ncurrent value: #{HighLine.color(param.value_to_s, :info)}"
+      say "\ncurrent value: #{HighLine.color(param.value_to_s, :notice)}"
       ask("new value:")
     end
 
     def configure_multi(param)
-      say HighLine.color('every line is a separate value, blank line to quit, for hash use key:value syntax', :info)
-      say "\ncurrent value: #{HighLine.color(param.value_to_s, :info)} %>"
+      say HighLine.color('every line is a separate value, blank line to quit, for hash use key:value syntax', :notice)
+      say "\ncurrent value: #{HighLine.color(param.value_to_s, :notice)} %>"
       ask("new value:") do |q|
         q.gather = ""
       end
@@ -164,7 +164,7 @@ END
         say "\n" + HighLine.color("Resetting parameters of module #{mod.name}", :headline)
         choose do |menu|
           mod.params.each do |param|
-            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :info)}, default value: #{HighLine.color(param.default_to_s, :info)}" do
+            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :notice)}, default value: #{HighLine.color(param.default_to_s, :notice)}" do
               reset(param)
             end if param.visible?(@kafo.params)
           end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -83,7 +83,7 @@ module Kafo
         it 'must apply but not persist value' do
           File.open("#{INSTALLER_HOME}/testing", 'w') { |f| f.write('3.0') }
 
-          code, out, err = run_command '../bin/kafo-configure -n -v --testing-version 2.0'
+          code, out, err = run_command '../bin/kafo-configure -n -v -l debug --testing-version 2.0'
           _(code).must_equal 0, err
           _(out).must_match %r{#{Regexp.escape(INSTALLER_HOME)}/testing.*content}
           _(File.read("#{INSTALLER_HOME}/testing")).must_equal '3.0'

--- a/test/kafo/puppet_log_parser_test.rb
+++ b/test/kafo/puppet_log_parser_test.rb
@@ -8,8 +8,8 @@ module Kafo
       subject { PuppetLogParser.new }
       specify { _(subject.parse('Error: foo')).must_equal [:error, 'foo'] }
       specify { _(subject.parse('Err: foo')).must_equal [:error, 'foo'] }
-      specify { _(subject.parse('Warning: foo')).must_equal [:warn, 'foo'] }
-      specify { _(subject.parse('Notice: foo')).must_equal [:warn, 'foo'] }
+      specify { _(subject.parse('Warning: foo')).must_equal [:debug, 'foo'] }
+      specify { _(subject.parse('Notice: foo')).must_equal [:info, 'foo'] }
       specify { _(subject.parse('Debug: foo')).must_equal [:debug, 'foo'] }
       specify { _(subject.parse('unknown foo')).must_equal [:info, 'unknown foo'] }
       specify do


### PR DESCRIPTION
More often than not, the messages coming form puppet that has a level of warn is of the following:

```
[ WARN 2020-09-10T20:59:45 verbose] /Stage[main]/Foreman::Config/File[/etc/foreman/dynflow]: Skipping because of failed dependencies
[ WARN 2020-09-10T20:59:45 verbose] /Stage[main]/Foreman::Config/File[/etc/foreman/email.yaml]: Skipping because of failed dependencies
[ WARN 2020-09-10T20:59:45 verbose] /Stage[main]/Foreman::Config/File[/usr/share/foreman]: Skipping because of failed dependencies
[ WARN 2020-09-10T20:59:45 verbose] /Stage[main]/Foreman::Config/Group[foreman]: Skipping because of failed dependencies
```

In the context of the installer, this generally does not provide users with useful information as the cause of the skipped dependencies is due to an `ERROR` level message. This change moves the puppet warn / notice to a debug so that it is stilled captured in the log files as debug output. This aims to help `verbose` mode output the most pertinent information to a user when using `info` as the base level output.