### PR TITLE
Label some options as advanced and hide by default

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -295,33 +295,39 @@ module Kafo
 
     def set_app_options
       self.class.app_option ['--[no-]colors'], :flag, 'Use color output on STDOUT',
-                            :default => !!config.app[:colors]
+                            :default => !!config.app[:colors], :advanced => true
       self.class.app_option ['--color-of-background'], 'COLOR', 'Your terminal background is :bright or :dark',
-                            :default => config.app[:color_of_background]
+                            :default => config.app[:color_of_background], :advanced => true
       self.class.app_option ['--dont-save-answers'], :flag, "Skip saving answers to '#{self.class.config.answer_file}'?",
-                            :default => !!config.app[:dont_save_answers]
+                            :default => !!config.app[:dont_save_answers], :advanced => true
       self.class.app_option '--ignore-undocumented', :flag, 'Ignore inconsistent parameter documentation',
-                            :default => false
+                            :default => false, :advanced => true
       self.class.app_option ['-i', '--interactive'], :flag, 'Run in interactive mode'
       self.class.app_option '--log-level', 'LEVEL', 'Log level for log file output',
-                            :default => config.app[:log_level]
+                            :default => config.app[:log_level], :advanced => true
       self.class.app_option ['-n', '--noop'], :flag, 'Run puppet in noop mode?',
                             :default => false
       self.class.app_option ['-p', '--profile'], :flag, 'Run puppet in profile mode?',
-                            :default => false
-      self.class.app_option ['-s', '--skip-checks-i-know-better'], :flag, 'Skip all system checks', :default => false
-      self.class.app_option ['--skip-puppet-version-check'], :flag, 'Skip check for compatible Puppet versions', :default => false
+                            :default => false, :advanced => true
+      self.class.app_option ['-s', '--skip-checks-i-know-better'], :flag, 'Skip all system checks', :default => false, :advanced => true
+      self.class.app_option ['--skip-puppet-version-check'], :flag, 'Skip check for compatible Puppet versions', :default => false, :advanced => true
       self.class.app_option ['-v', '--verbose'], :flag, 'Display log on STDOUT instead of progressbar'
       self.class.app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
                             :default => 'info'
       self.class.app_option ['-S', '--scenario'], 'SCENARIO', 'Use installation scenario'
-      self.class.app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario'
-      self.class.app_option ['--enable-scenario'], 'SCENARIO', 'Enable installation scenario'
       self.class.app_option ['--list-scenarios'], :flag, 'List available installation scenarios'
-      self.class.app_option ['--force'], :flag, 'Force change of installation scenario'
-      self.class.app_option ['--compare-scenarios'], :flag, 'Show changes between last used scenario and the scenario specified with -S or --scenario argument'
-      self.class.app_option ['--migrations-only'], :flag, 'Apply migrations to a selected scenario and exit'
-      self.class.app_option ['--[no-]parser-cache'], :flag, 'Force use or bypass of Puppet module parser cache'
+      self.class.app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario',
+                            :advanced => true
+      self.class.app_option ['--enable-scenario'], 'SCENARIO', 'Enable installation scenario',
+                            :advanced => true
+      self.class.app_option ['--force'], :flag, 'Force change of installation scenario',
+                            :advanced => true
+      self.class.app_option ['--compare-scenarios'], :flag, 'Show changes between last used scenario and the scenario specified with -S or --scenario argument',
+                            :advanced => true
+      self.class.app_option ['--migrations-only'], :flag, 'Apply migrations to a selected scenario and exit',
+                            :advanced => true
+      self.class.app_option ['--[no-]parser-cache'], :flag, 'Force use or bypass of Puppet module parser cache',
+                            :advanced => true
     end
 
     def set_options
@@ -331,10 +337,13 @@ module Kafo
       end
 
       modules.each do |mod|
-        self.class.option d("--[no-]enable-#{mod.name}"),
-                          :flag,
-                          "Enable '#{mod.name}' puppet module",
-                          :default => mod.enabled?
+        self.class.app_option(
+          d("--[no-]enable-#{mod.name}"),
+          :flag,
+          "Enable '#{mod.name}' puppet module",
+          :default => mod.enabled?,
+          :advanced => true
+        )
       end
 
       params.sort.each do |param|

--- a/test/kafo/help_builders/advanced_test.rb
+++ b/test/kafo/help_builders/advanced_test.rb
@@ -33,7 +33,7 @@ module Kafo
       end
 
       let(:stdout) { StringIO.new }
-      let(:builder) { HelpBuilders::Advanced.new(params) }
+      let(:builder) { HelpBuilders::Advanced.new(params, {}) }
 
       before { builder.instance_variable_set '@out', stdout }
 

--- a/test/kafo/help_builders/basic_test.rb
+++ b/test/kafo/help_builders/basic_test.rb
@@ -43,7 +43,7 @@ module Kafo
       end
 
       let(:stdout) { StringIO.new }
-      let(:builder) { HelpBuilders::Basic.new(params) }
+      let(:builder) { HelpBuilders::Basic.new(params, {}) }
 
       before { builder.instance_variable_set '@out', stdout }
 
@@ -72,6 +72,84 @@ module Kafo
         specify { _(output).wont_include 'Advanced' }
         specify { _(output).must_match(/Generic.*Module apache.*Module puppet/m) }
         specify { _(output).wont_include '= Module redis:' }
+      end
+
+      describe "#string" do
+        specify { _(builder.string).must_include 'Only commonly used options have been displayed' }
+        specify { _(builder.string).must_include 'Use --full-help to view the complete list.' }
+      end
+    end
+
+    describe "basic with hidden advanced" do
+      let(:params) do
+        [
+            Param.new(OpenStruct.new(:name => 'puppet'), 'version', 'String').tap do |p|
+              p.doc    = "version parameter"
+              p.groups = []
+            end,
+            Param.new(OpenStruct.new(:name => 'puppet'), 'server', 'Boolean').tap do |p|
+              p.doc    = "enable puppetmaster server"
+              p.groups = ["Advanced parameters:"]
+            end,
+            Param.new(OpenStruct.new(:name => 'puppet'), 'port', 'Integer').tap do |p|
+              p.doc    = "puppetmaster port"
+              p.groups = ["Advanced parameters:"]
+            end,
+            Param.new(OpenStruct.new(:name => 'apache'), 'port', 'Integer').tap do |p|
+              p.doc    = "apache port"
+              p.groups = []
+            end,
+        ]
+      end
+
+      let(:clamp_definitions) do
+        [
+            OpenStruct.new(:help => ['--puppet-version', 'version parameter (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-puppet-version', 'Reset version to the default value (default: "bar")']),
+            OpenStruct.new(:help => ['--puppet-server', 'enable puppetmaster server (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-puppet-server', 'Reset server to the default value (default: "bar")']),
+            OpenStruct.new(:help => ['--puppet-port', 'puppetmaster port (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-puppet-port', 'Reset port to the default value (default: "bar")']),
+            OpenStruct.new(:help => ['--help', 'app wide argument, not advanced'], :attribute_name => 'help'),
+            OpenStruct.new(:help => ['--no-colors', 'app wide argument, not a parameter'], :attribute_name => 'no_colors'),
+            OpenStruct.new(:help => ['--apache-port', 'apache module parameter (current: "foo")']),
+            OpenStruct.new(:help => ['--reset-apache-port', 'Reset port to the default value (default: "bar")']),
+        ]
+      end
+
+      let(:stdout) { StringIO.new }
+      let(:builder) do
+        HelpBuilders::Basic.new(params, :app_options => {'no_colors' => {:advanced => true}})
+      end
+
+      before { builder.instance_variable_set '@out', stdout }
+
+      # note that these test do not preserve any order
+      describe "#add_list" do
+        before { builder.add_list('Options', clamp_definitions) }
+
+        let(:output) { stdout.rewind; stdout.read }
+
+        specify { _(output).must_include 'Options' }
+        specify { _(output).must_include '= Generic:' }
+        specify { _(output).wont_include '--no-colors' }
+        specify { _(output).wont_include 'app wide argument, not a parameter' }
+        specify { _(output).must_include '= Module puppet:' }
+        specify { _(output).must_include '--puppet-version' }
+        specify { _(output).must_include 'version parameter' }
+        specify { _(output).wont_include '--reset-puppet-version' }
+        specify { _(output).wont_include 'reset puppet-version' }
+        specify { _(output).wont_include '--puppet-server' }
+        specify { _(output).wont_include 'enable puppetmaster server' }
+        specify { _(output).wont_include '--reset-puppet-server' }
+        specify { _(output).wont_include 'reset puppet-server' }
+        specify { _(output).wont_include '--puppet-port' }
+        specify { _(output).wont_include 'puppetmaster port' }
+        specify { _(output).wont_include '--reset-puppet-port' }
+        specify { _(output).wont_include 'reset puppet-port' }
+        specify { _(output).wont_include 'Basic' }
+        specify { _(output).wont_include 'Advanced' }
+        specify { _(output).must_match(/Generic.*Module apache.*Module puppet/m) }
       end
 
       describe "#string" do


### PR DESCRIPTION
This introduces labeling some options as advanced and hiding them
under an Advanced section that is by default not displayed with
--help. These options are visible if a user supplies --full-help.
This aims to reduce the amount of options presented to a user when
using an installer based on Kafo at it's basic level.

This implementation also allows options created through hooks to label themselves as advanced

Example of change in the output after supplying `--full-help`:

```
= Generic:
    --reset-data                  This option will drop all databases for Foreman and subsequent backend systems. You will lose all data!
                                  Unfortunately, we can't detect a failure, so you should verify success manually.
                                  Dropping can fail when the DB is in use. (default: false)
    --detailed-exitcodes          Provide transaction information via exit codes, see puppet-agent(8)
                                  for full details. (default: false)
    -i, --interactive             Run in interactive mode
    --log-level LEVEL             Log level for log file output (default: :debug)
    -n, --noop                    Run puppet in noop mode? (default: false)
    -s, --skip-checks-i-know-better Skip all system checks (default: false)
    -v, --verbose                 Display log on STDOUT instead of progressbar
    -l, --verbose-log-level LEVEL Log level for verbose mode output (default: "info")
    -S, --scenario SCENARIO       Use installation scenario
    -h, --help                    print help
    --full-help                   print complete help

= Advanced:
    --[no-]colors                 Use color output on STDOUT (default: true)
    --color-of-background COLOR   Your terminal background is :bright or :dark (default: :dark)
    --dont-save-answers           Skip saving answers to './config/foreman-answers.yaml'? (default: false)
    --ignore-undocumented         Ignore inconsistent parameter documentation (default: false)
    -p, --profile                 Run puppet in profile mode? (default: false)
    --skip-puppet-version-check   Skip check for compatible Puppet versions (default: false)
    --disable-scenario SCENARIO   Disable installation scenario
    --enable-scenario SCENARIO    Enable installation scenario
    --list-scenarios              List available installation scenarios
    --force                       Force change of installation scenario
    --compare-scenarios           Show changes between last used scenario and the scenario specified with -S or --scenario argument
    --migrations-only             Apply migrations to a selected scenario and exit
    --[no-]parser-cache           Force use or bypass of Puppet module parser cache
    --[no-]enable-foreman         Enable 'foreman' puppet module (default: true)
    --[no-]enable-foreman-cli     Enable 'foreman_cli' puppet module (default: true)
    --[no-]enable-foreman-cli-ansible Enable 'foreman_cli_ansible' puppet module (default: false)
    --[no-]enable-foreman-cli-azure Enable 'foreman_cli_azure' puppet module (default: false)
    --[no-]enable-foreman-cli-discovery Enable 'foreman_cli_discovery' puppet module (default: false)
    --[no-]enable-foreman-cli-kubevirt Enable 'foreman_cli_kubevirt' puppet module (default: false)
    --[no-]enable-foreman-cli-openscap Enable 'foreman_cli_openscap' puppet module (default: false)
    --[no-]enable-foreman-cli-remote-execution Enable 'foreman_cli_remote_execution' puppet module (default: false)
    --[no-]enable-foreman-cli-tasks Enable 'foreman_cli_tasks' puppet module (default: false)
    --[no-]enable-foreman-cli-templates Enable 'foreman_cli_templates' puppet module (default: false)
    --[no-]enable-foreman-proxy   Enable 'foreman_proxy' puppet module (default: true)
    --[no-]enable-puppet          Enable 'puppet' puppet module (default: true)
    --[no-]enable-foreman-plugin-ansible Enable 'foreman_plugin_ansible' puppet module (default: false)
    --[no-]enable-foreman-plugin-azure Enable 'foreman_plugin_azure' puppet module (default: false)
    --[no-]enable-foreman-plugin-bootdisk Enable 'foreman_plugin_bootdisk' puppet module (default: false)
    --[no-]enable-foreman-plugin-chef Enable 'foreman_plugin_chef' puppet module (default: false)
    --[no-]enable-foreman-plugin-default-hostgroup Enable 'foreman_plugin_default_hostgroup' puppet mod
```