### PR TITLE
Do not display a module in help if no options

### DIFF
--- a/lib/kafo/help_builders/base.rb
+++ b/lib/kafo/help_builders/base.rb
@@ -15,6 +15,7 @@ module Kafo
       end
 
       def add_list(heading, items)
+        return if items.empty?
         if heading == 'Options'
           puts "\n#{heading}:"
 

--- a/test/kafo/help_builders/basic_test.rb
+++ b/test/kafo/help_builders/basic_test.rb
@@ -21,6 +21,10 @@ module Kafo
               p.doc    = "apache port"
               p.groups = []
             end,
+            Param.new(OpenStruct.new(:name => 'redis'), 'port', 'Integer').tap do |p|
+              p.doc    = "redis port"
+              p.groups = ["Advanced parameters:"]
+            end,
         ]
       end
 
@@ -67,6 +71,7 @@ module Kafo
         specify { _(output).wont_include 'Basic' }
         specify { _(output).wont_include 'Advanced' }
         specify { _(output).must_match(/Generic.*Module apache.*Module puppet/m) }
+        specify { _(output).wont_include '= Module redis:' }
       end
 
       describe "#string" do


### PR DESCRIPTION
If a module has no options, either through none in the docs or
because all options are advanced, this prevents them from showing
up and cluttering the help output.

Example of the bug, see middle area for `= Module foreman_proxy_plugin_pulp:`:

```
= Module foreman_proxy_plugin_openscap:
    --foreman-proxy-plugin-openscap-contentdir  Directory where OpenSCAP content XML are stored
                                  So we will not request the XML from Foreman each time (current: "/var/lib/foreman-proxy/openscap/content")
    --foreman-proxy-plugin-openscap-corrupted-dir  Directory where corrupted OpenSCAP report XML are stored (current: "/var/lib/foreman-proxy/openscap/corrupted")
    --foreman-proxy-plugin-openscap-failed-dir  Directory where OpenSCAP report XML are stored
                                  In case sending to Foreman succeeded, yet failed to save to reportsdir (current: "/var/lib/foreman-proxy/openscap/failed")
    --foreman-proxy-plugin-openscap-openscap-send-log-file  Log file for the forwarding script (current: "/var/log/foreman-proxy/openscap-send.log")
    --foreman-proxy-plugin-openscap-proxy-name  Proxy name to send to Foreman with parsed report
                                  Foreman matches it against names of registered proxies to find the report source (current: UNDEF)
    --foreman-proxy-plugin-openscap-reportsdir  Directory where OpenSCAP report XML are stored
                                  So Foreman can request arf xml reports (current: "/var/lib/foreman-proxy/openscap/reports")
    --foreman-proxy-plugin-openscap-spooldir  Directory where OpenSCAP audits are stored
                                  before they are forwarded to Foreman (current: "/var/spool/foreman-proxy/openscap")
    --foreman-proxy-plugin-openscap-timeout  Timeout for sending ARF reports to foreman (current: 60)


= Module foreman_proxy_plugin_pulp:


= Module foreman_proxy_plugin_remote_execution_ssh:
    --foreman-proxy-plugin-remote-execution-ssh-generate-keys  Automatically generate SSH keys (current: true)
    --foreman-proxy-plugin-remote-execution-ssh-install-key  Automatically install generated SSH key to root authorized keys
                                  which allows managing this host through Remote Execution (current: false)
    --foreman-proxy-plugin-remote-execution-ssh-local-working-dir  Local working directory on the smart proxy (current: "/var/tmp")
    --foreman-proxy-plugin-remote-execution-ssh-remote-working-dir  Remote working directory on clients (current: "/var/tmp")
    --foreman-proxy-plugin-remote-execution-ssh-ssh-identity-dir  Directory where SSH keys are stored (current: "/var/lib/foreman-proxy/ssh")
    --foreman-proxy-plugin-remote-execution-ssh-ssh-identity-file  Provide an alternative name for the SSH keys (current: "id_rsa_foreman_proxy")
    --foreman-proxy-plugin-remote-execution-ssh-ssh-kerberos-auth  Enable kerberos authentication for SSH (current: false)
    --foreman-proxy-plu
```