### PR TITLE
Only show scenario options when multiple are available

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -310,12 +310,16 @@ module Kafo
       self.class.app_option ['-v', '--verbose'], :flag, 'Display log on STDOUT instead of progressbar'
       self.class.app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
                             :default => 'info'
+
       self.class.app_option ['-S', '--scenario'], 'SCENARIO', 'Use installation scenario'
-      self.class.app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario'
-      self.class.app_option ['--enable-scenario'], 'SCENARIO', 'Enable installation scenario'
       self.class.app_option ['--list-scenarios'], :flag, 'List available installation scenarios'
-      self.class.app_option ['--force'], :flag, 'Force change of installation scenario'
-      self.class.app_option ['--compare-scenarios'], :flag, 'Show changes between last used scenario and the scenario specified with -S or --scenario argument'
+      if scenario_manager.multiple_scenarios_available?
+        self.class.app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario'
+        self.class.app_option ['--enable-scenario'], 'SCENARIO', 'Enable installation scenario'
+        self.class.app_option ['--force'], :flag, 'Force change of installation scenario'
+        self.class.app_option ['--compare-scenarios'], :flag, 'Show changes between last used scenario and the scenario specified with -S or --scenario argument'
+      end
+
       self.class.app_option ['--migrations-only'], :flag, 'Apply migrations to a selected scenario and exit'
       self.class.app_option ['--[no-]parser-cache'], :flag, 'Force use or bypass of Puppet module parser cache'
     end

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -43,6 +43,10 @@ module Kafo
       KafoConfigure.exit(0)
     end
 
+    def multiple_scenarios_available?
+      available_scenarios.length > 1
+    end
+
     def scenario_selection_wizard
       wizard = KafoWizards.wizard(:cli, 'Select installation scenario',
         :description => "Please select one of the pre-set installation scenarios. You can customize your setup later during the installation.")


### PR DESCRIPTION
This removes the option to disable and enable scenarios when there's only a single one available. That assumes the scenario is already enabled.

If there is only one, there is also no reason to switch scenarios. That makes force and compare not needed.

The --scenario and --list-scenarios are kept in because instructions can refer to an explicit scenario. That keeps the installation manual consistent.

This is completely untested, but it's here to illustrate the point I made in https://github.com/theforeman/kafo/pull/280/files#r499792034.