### PR TITLE
Change installer finished runtime message to debug level

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -118,7 +118,7 @@ module Kafo
       logger.info("Running installer with args #{args.inspect}")
       super
     ensure
-      logger.info("Installer finished in #{Time.now - started_at} seconds")
+      logger.debug("Installer finished in #{Time.now - started_at} seconds")
     end
 
     def execute


### PR DESCRIPTION
This moves the runtime information to debug output and gives full
control over the installer to output final messages to the user.

Prior to this change post install messages were not the last thing a user saw:

```
2020-10-07 17:35:11 [INFO ] [post] Executing hooks in group post
2020-10-07 17:35:11 [INFO ] [post] All hooks in group post finished
  Something went wrong! Check the log for ERROR-level output
  The full log is at ./_build/foreman.log
2020-10-07 17:35:11 [INFO ] [root] Installer finished in 43.959447996 seconds
```

With this change, the 'finished in' message is now debug output and allows the installer full control:

```
because of failed dependencies
2020-10-07 17:58:58 [ERROR] [configure] Could not find a suitable provider for augeas
2020-10-07 17:58:58 [ERROR] [configure] Could not find a suitable provider for foreman_smartproxy
2020-10-07 17:58:58 [WARN ] [configure] Applied catalog in 18.23 seconds
2020-10-07 17:58:58 [INFO ] [post] Executing hooks in group post
2020-10-07 17:58:58 [INFO ] [post] All hooks in group post finished
  Something went wrong! Check the log for ERROR-level output
  The full log is at ./_build/foreman.log
```

A more invasive alternative is to add a special 'install messages' hook similar to -- https://github.com/ehelms/kafo/commit/bd3f2956c0723815c2bfe356bc49eb03daef937b