### PR TITLE
Add a puppet_execution_environment hook method

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -169,8 +169,6 @@ module Kafo
         execution_env = ExecutionEnvironment.new(self)
         KafoConfigure.exit_handler.register_cleanup_path(execution_env.directory)
 
-        puppetconf = execution_env.configure_puppet('noop' => true)
-
         dump_manifest = <<EOS
           #{includes}
           class { '::kafo_configure::dump_values':
@@ -180,8 +178,8 @@ module Kafo
 EOS
 
         @logger.info 'Loading default values from puppet modules...'
-        command = PuppetCommand.new(dump_manifest, [], puppetconf, self).command
-        stdout, stderr, status = Open3.capture3(*PuppetCommand.format_command(command))
+        command = execution_env.build_command(dump_manifest, settings: {'noop' => true})
+        stdout, stderr, status = Open3.capture3(*command)
 
         @logger.debug stdout
         @logger.debug stderr

--- a/lib/kafo/execution_environment.rb
+++ b/lib/kafo/execution_environment.rb
@@ -42,6 +42,13 @@ module Kafo
       PuppetConfigurer.new(puppet_conf, settings)
     end
 
+    def build_command(code, options: [], settings: {}, use_answers: false)
+      store_answers if use_answers
+      puppetconf = configure_puppet(settings)
+      command = Kafo::PuppetCommand.new(code, options, puppetconf, @config).command
+      Kafo::PuppetCommand.format_command(command)
+    end
+
     private
 
     def environmentpath

--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -1,3 +1,4 @@
+require 'fileutils'
 require 'kafo/data_type'
 require 'kafo/base_context'
 
@@ -133,6 +134,14 @@ module Kafo
     # Return the actual data in the current scenario
     def scenario_data
       self.kafo.config.app
+    end
+
+    # Yield a Puppet execution environment that's isolated from the system
+    def puppet_execution_environment
+      execution_env = Kafo::ExecutionEnvironment.new(self.kafo.config)
+      yield execution_env
+    ensure
+      FileUtils.rm_rf(execution_env.directory)
     end
   end
 end

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -425,14 +425,14 @@ module Kafo
       execution_env = ExecutionEnvironment.new(config)
       self.class.exit_handler.register_cleanup_path(execution_env.directory)
 
-      execution_env.store_answers
-      puppetconf = execution_env.configure_puppet(
+      code = 'include kafo_configure'
+      settings = {
         'color'     => false,
         'evaltrace' => !!@progress_bar,
         'noop'      => !!noop?,
         'profile'   => !!profile?,
         'show_diff' => true,
-      )
+      }
 
       exit_code   = 0
       exit_status = nil
@@ -442,11 +442,11 @@ module Kafo
           '--detailed-exitcodes',
       ]
       begin
-        command = PuppetCommand.new('include kafo_configure', options, puppetconf).command
+        command = execution_env.build_command(code, options: options, settings: settings, use_answers: true)
         log_parser = PuppetLogParser.new
         logger = Logger.new('configure')
 
-        PTY.spawn(*PuppetCommand.format_command(command)) do |stdin, stdout, pid|
+        PTY.spawn(*command) do |stdin, stdout, pid|
           begin
             stdin.each do |line|
               line = normalize_encoding(line)


### PR DESCRIPTION
This makes it easy to run Puppet code in hooks. To achieve this, ExecutionEnvironment also gains `build_command`. Existing code is refactored to make use of this.