### PR TITLE
Implement multi hooks

### DIFF
--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -1,4 +1,5 @@
 require 'kafo/hook_context'
+require 'kafo/multi_stage_hook'
 
 module Kafo
   class Hooking
@@ -35,6 +36,14 @@ module Kafo
             register(hook_type, file, &hook_block)
           end
         end
+
+        # Multi stage hooks are special
+        Dir.glob(File.join(base_dir, 'multi', '*.rb')).sort.each do |file|
+          logger.debug "Loading multi stage hook #{file}"
+          hook = File.read(file)
+          MultiStageHook.new(file, self, TYPES).instance_eval(hook, file, 1)
+        end
+
         @loaded = true
       end
       self

--- a/lib/kafo/multi_stage_hook.rb
+++ b/lib/kafo/multi_stage_hook.rb
@@ -1,0 +1,13 @@
+module Kafo
+  class MultiStageHook
+    def initialize(name, registry, types)
+      default_name = name
+
+      types.each do |hook_type|
+        self.class.send(:define_method, hook_type) do |name=nil, &block|
+          registry.send(:register, hook_type, name || default_name, &block)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Multi hooks are a special hook that allow you to define multiple hook stages within a single file. This can to avoid duplication of things like constants.

Currently still a draft since I haven't written documentation nor tests.