### PR TITLE
Make Puppet reports available from the ExecEnv

### DIFF
--- a/lib/kafo/execution_environment.rb
+++ b/lib/kafo/execution_environment.rb
@@ -19,6 +19,18 @@ module Kafo
       end
     end
 
+    def reportdir
+      @reportdir ||= begin
+        path = File.join(directory, 'reports')
+        File.mkdir(path)
+        path
+      end
+    end
+
+    def reports
+      Dir.entries(reportdir).sort_by { |path| File.mtime(path) }
+    end
+
     def store_answers
       answer_data = HieraConfigurer.generate_data(@config.modules, @config.app[:order])
       @logger.debug("Writing temporary answers to #{answer_file}")
@@ -37,6 +49,8 @@ module Kafo
         'environmentpath' => environmentpath,
         'factpath'        => factpath,
         'hiera_config'    => hiera_config,
+        'reports'         => 'store',
+        'reportdir'       => reportdir,
       }.merge(settings)
 
       PuppetConfigurer.new(puppet_conf, settings)

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -22,6 +22,7 @@ require 'kafo/wizard'
 require 'kafo/system_checker'
 require 'kafo/puppet_command'
 require 'kafo/puppet_log_parser'
+require 'kafo/puppet_report'
 require 'kafo/progress_bar'
 require 'kafo/hooking'
 require 'kafo/exit_handler'
@@ -472,7 +473,13 @@ module Kafo
       @progress_bar.close if @progress_bar
       logger.info "Puppet has finished, bye!"
 
+      last_report = execution_env.reports.last
+      if last_report
+        report = PuppetReport.load_report_file(report)
+      end
+
       self.class.exit(exit_code) do
+        # TODO: make report available in the post context
         self.class.hooking.execute(:post)
       end
     end

--- a/lib/kafo/puppet_report.rb
+++ b/lib/kafo/puppet_report.rb
@@ -1,0 +1,34 @@
+module Kafo
+  # An abstraction over the Puppet report format
+  #
+  # @see https://puppet.com/docs/puppet/6.18/format_report.html
+  class PuppetReport
+    attr_reader :report
+
+    def self.load_report_file(path)
+      raise ArgumentError, 'No path given' unless path || path.empty?
+      raise ArgumentError, "#{path} is not a readable file" unless File.file?(path) && File.readable?(path)
+
+      data = case File.extname(path)
+             when '.yaml'
+               require 'yaml'
+               YAML.load_file(path)
+             when '.json'
+               require 'json'
+               JSON.parse(File.read(path))
+             else
+               raise ArgumentError, "Unsupported file extension for #{path}"
+             end
+
+      PuppetReport.new(data)
+    end
+
+    def initialize(report)
+      @report = report
+    end
+
+    def report_format
+      report['report_format']
+    end
+  end
+end


### PR DESCRIPTION
Puppet produces reports. These can be used to produce good instructions to users about what exactly failed.

This is just the initial structure - it doesn't actually work yet and no useful information is retrieved from the actual report.