### PR TITLE
Allow configuring verbose in config file

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -32,6 +32,7 @@ module Kafo
         :custom               => {},
         :facts                => {},
         :low_priority_modules => [],
+        :verbose              => false,
         :verbose_log_level    => 'notice',
         :skip_puppet_version_check => false,
         :parser_cache_path    => nil,

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -331,7 +331,8 @@ module Kafo
                  :default => false
       app_option ['--skip-puppet-version-check'], :flag, 'Skip check for compatible Puppet versions',
                  :default => false, :advanced => true
-      app_option ['-v', '--verbose'], :flag, 'Display log on STDOUT instead of progressbar'
+      app_option ['-v', '--[no-]verbose'], :flag, 'Display log on STDOUT instead of progressbar',
+                 :default => config.app[:verbose]
       app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
                  :default => 'notice'
       app_option ['-S', '--scenario'], 'SCENARIO', 'Use installation scenario'

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -58,6 +58,13 @@ module Kafo
         _(code.exitstatus).must_equal 20, err
         _(File.exist?("#{INSTALLER_HOME}/testing")).must_equal false
       end
+
+      it 'must default verbose to false' do
+        code, _, err = run_command '../bin/kafo-configure'
+
+        _(code).must_equal 0, err
+        _(YAML.load_file(KAFO_CONFIG)[:verbose]).must_equal false
+      end
     end
 
     describe '--noop' do
@@ -65,6 +72,57 @@ module Kafo
         code, _, err = run_command '../bin/kafo-configure -n'
         _(code).must_equal 0, err
         _(File.exist?("#{INSTALLER_HOME}/testing")).must_equal false
+      end
+    end
+
+    describe 'verbose in the config file' do
+      it 'must respect verbose true' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:verbose] = true
+        File.open(KAFO_CONFIG, "w") { |file| file.write(config.to_yaml) }
+
+        code, stdout, err = run_command '../bin/kafo-configure'
+
+        _(code).must_equal 0, err
+        _(stdout).must_include "NOTICE"
+        _(YAML.load_file(KAFO_CONFIG)[:verbose]).must_equal true
+      end
+
+      it 'must respect verbose false' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:verbose] = false
+        File.open(KAFO_CONFIG, "w") { |file| file.write(config.to_yaml) }
+
+        code, stdout, err = run_command '../bin/kafo-configure'
+
+        _(code).must_equal 0, err
+        _(stdout).wont_include "NOTICE"
+        _(YAML.load_file(KAFO_CONFIG)[:verbose]).must_equal false
+      end
+
+      it 'must respect --verbose' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:verbose] = false
+        File.open(KAFO_CONFIG, "w") { |file| file.write(config.to_yaml) }
+
+        code, stdout, err = run_command '../bin/kafo-configure --verbose'
+
+        _(code).must_equal 0, err
+        _(stdout).must_include "NOTICE"
+        _(YAML.load_file(KAFO_CONFIG)[:verbose]).must_equal true
+      end
+
+      it 'must respect --no-verbose' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:verbose] = true
+        File.open(KAFO_CONFIG, "w") { |file| file.write(config.to_yaml) }
+
+        code, stdout, err = run_command '../bin/kafo-configure --no-verbose'
+        updated_config = YAML.load_file(KAFO_CONFIG)
+
+        _(code).must_equal 0, err
+        _(stdout).wont_include "NOTICE"
+        _(updated_config[:verbose]).must_equal false
       end
     end
 


### PR DESCRIPTION
To allow a scenario to configure verbose mode by default, verbose has to be allowed as a parameter in the config and the code handling the input from the user has to recognize when to overwrite this from the user and when to avoid it due to potential default answers.