### PR TITLE
Only save configuration values defined to be persisted

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -15,6 +15,8 @@ module Kafo
         :description          => '',
         :enabled              => true,
         :log_dir              => '/var/log/kafo',
+        :log_owner            => nil,
+        :log_group            => nil,
         :store_dir            => '',
         :log_name             => 'configuration.log',
         :log_level            => 'notice',
@@ -26,11 +28,19 @@ module Kafo
         :colors               => Kafo::ColorScheme.colors_possible?,
         :color_of_background  => :dark,
         :hook_dirs            => [],
+        :check_dirs           => nil,
         :custom               => {},
         :facts                => {},
         :low_priority_modules => [],
         :verbose_log_level    => 'notice',
-        :skip_puppet_version_check => false
+        :skip_puppet_version_check => false,
+        :parser_cache_path    => nil,
+        :ignore_undocumented  => nil,
+        :order                => nil,
+        :hiera_config         => nil,
+        :kafo_modules_dir     => nil,
+        :config_header_file   => nil,
+        :dont_save_answers    => nil,
     }
 
     def self.get_scenario_id(filename)
@@ -57,11 +67,16 @@ module Kafo
 
     def save_configuration(configuration)
       return true unless @persist
+
+      trimmed = configuration.reject do |key, value|
+        !DEFAULT.key?(key) || value.nil?
+      end
+
       begin
         FileUtils.touch @config_file
         File.chmod 0600, @config_file
         File.open(@config_file, 'w') do |file|
-          file.write(format(YAML.dump(configuration.sort.to_h)))
+          file.write(format(YAML.dump(trimmed.sort.to_h)))
         end
       rescue Errno::EACCES
         puts "Insufficient permissions to write to #{@config_file}, can not continue"

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -198,6 +198,7 @@ module Kafo
 
       self.class.hooking.execute(:pre_commit)
       unless dont_save_answers? || noop?
+        config.configure_application
         store_params
         self.class.scenario_manager.link_last_scenario(self.class.config_file) if self.class.scenario_manager.configured?
       end
@@ -312,13 +313,13 @@ module Kafo
 
     def set_app_options
       app_option ['--[no-]colors'], :flag, 'Use color output on STDOUT',
-                 :default => !!config.app[:colors], :advanced => true
+                 :default => config.app[:colors], :advanced => true
       app_option ['--color-of-background'], 'COLOR', 'Your terminal background is :bright or :dark',
                  :default => config.app[:color_of_background], :advanced => true
       app_option ['--dont-save-answers'], :flag, "Skip saving answers to '#{self.class.config.answer_file}'?",
-                 :default => !!config.app[:dont_save_answers], :advanced => true
+                 :default => config.app[:dont_save_answers], :advanced => true
       app_option '--ignore-undocumented', :flag, 'Ignore inconsistent parameter documentation',
-                 :default => false, :advanced => true
+                 :default => config.app[:ignore_undocumented], :advanced => true
       app_option ['-i', '--interactive'], :flag, 'Run in interactive mode'
       app_option '--log-level', 'LEVEL', 'Log level for log file output',
                  :default => config.app[:log_level], :advanced => true


### PR DESCRIPTION
The entire application config can be persisted to disk but not every
item is meant to be saved to disk as they are designed to be
options the user passes during runtime and not enabled every
single run. This ensures only configuration defined in the
DEFAULTS hash is persisted to disk.

This also prevents the false assumption that changing a saved value
in the config will affect the next run which is not always true for
every value.