### PR TITLE
Fixes #29965 - Support highline 2.x

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ load 'tasks/jenkins.rake'
 
 Rake::TestTask.new('test:ruby') do |t|
   t.libs << 'lib' << 'test'
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList['test/**/*_test.rb'] - FileList['test/tmp/**/*_test.rb']
   t.verbose = true
 end
 

--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # CLI interface
   spec.add_dependency 'clamp', '>= 0.6.2', '< 1.3.1'
   # interactive mode
-  spec.add_dependency 'highline', '>= 1.6.21', '< 2.0'
+  spec.add_dependency 'highline', '>= 1.6.21', '< 3.0'
   # ruby progress bar
   spec.add_dependency 'powerbar'
 end

--- a/lib/kafo/color_scheme.rb
+++ b/lib/kafo/color_scheme.rb
@@ -1,4 +1,4 @@
-require 'highline/import'
+require 'highline'
 
 module Kafo
   class ColorScheme

--- a/lib/kafo/progress_bar.rb
+++ b/lib/kafo/progress_bar.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+require 'highline'
 require 'powerbar'
 require 'ansi/code'
 require 'set'
@@ -20,7 +21,7 @@ module Kafo
       @all_lines                                = 0
       @total                                    = :unknown
       @resources                                = Set.new
-      @term_width                               = HighLine::SystemExtensions.terminal_size[0] || 0
+      @term_width                               = terminal_width
       @bar                                      = PowerBar.new
       @bar.settings.tty.infinite.template.main  = infinite_template
       @bar.settings.tty.finite.template.main    = finite_template
@@ -84,6 +85,17 @@ module Kafo
     end
 
     private
+
+    def terminal_width
+      # HighLine 2 has Terminal, 1 has SystemExtensions
+      terminal_size = if HighLine.respond_to?(:default_instance)
+                        HighLine.default_instance.terminal.terminal_size
+                      else
+                        HighLine::SystemExtensions.terminal_size
+                      end
+
+      terminal_size ? (terminal_size[0] || 0) : 0
+    end
 
     def done_message
       text = 'Done'

--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+require 'highline/import'
 require 'kafo_wizards'
 require 'pathname'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,11 @@ require 'kafo'
 require 'ostruct'
 require 'dummy_logger'
 
+begin
+  require 'highline/io_console_compatible'
+rescue LoadError
+  # HighLine 1 doesn't need this
+end
 
 BASIC_CONFIGURATION = <<EOS
 :name: Basic


### PR DESCRIPTION
The biggest change in version 2 is dropping Highline::SystemExtensions in favor of Highline::Terminal.

Another big change is that the global $terminal is no longer set. Instead, it has HighLine.default_instance.

It also changes the highline import to only highline instead of highline/import where possible. This means that not everywhere there is a global agree/ask/choose/say. Since the scenario manager still uses highline/import, for hooks there is no change.

It still keeps highline 1.x support because that's shipped on Debian 10 and Ubuntu 18.04. It also allows for a smoother migration since other gems also use highline.