### PR TITLE
Determine color usage dynamically

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -23,7 +23,7 @@ module Kafo
         :answer_file          => './config/answers.yaml',
         :installer_dir        => '.',
         :module_dirs          => ['./modules'],
-        :colors               => Kafo::ColorScheme.colors_possible?,
+        :colors               => nil,
         :color_of_background  => :dark,
         :hook_dirs            => [],
         :custom               => {},
@@ -86,6 +86,10 @@ module Kafo
         result.delete(:modules_dir)
         result
       end
+    end
+
+    def use_colors?
+      app[:colors].nil? ? Kafo::ColorScheme.colors_possible? : app[:colors]
     end
 
     def get_custom(key)

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -125,7 +125,7 @@ module Kafo
       parse_cli_arguments
 
       if !config.app[:verbose]
-        @progress_bar = config.app[:colors] ? ProgressBars::Colored.new : ProgressBars::BlackWhite.new
+        @progress_bar = config.use_colors? ? ProgressBars::Colored.new : ProgressBars::BlackWhite.new
       end
 
       unless skip_checks_i_know_better?
@@ -291,7 +291,7 @@ module Kafo
 
     def set_app_options
       self.class.app_option ['--[no-]colors'], :flag, 'Use color output on STDOUT',
-                            :default => !!config.app[:colors]
+                            :default => config.use_colors?
       self.class.app_option ['--color-of-background'], 'COLOR', 'Your terminal background is :bright or :dark',
                             :default => config.app[:color_of_background]
       self.class.app_option ['--dont-save-answers'], :flag, "Skip saving answers to '#{self.class.config.answer_file}'?",
@@ -497,12 +497,14 @@ module Kafo
 
     def self.use_colors?
       if config
-        colors = config.app[:colors]
+        config.use_colors?
+      elsif ARGV.include?('--no-colors')
+        false
+      elsif ARGV.include?('--colors')
+        true
       else
-        colors = ARGV.include?('--no-colors') ? false : nil
-        colors = ARGV.include?('--colors') ? true : nil if colors.nil?
+        Kafo::ColorScheme.colors_possible?
       end
-      colors
     end
 
     def self.preset_color_scheme


### PR DESCRIPTION
This changes the color usage to be determined dynamically. Prior to this the config was always read. That meant that if the scenario was ever written to disk (using save_configuration), it stored the value of colors_possible? and uses that indefinitely.

After this change, the value of colors will remain nil (determined at runtime) until the user uses --[no-]colors, which is then persisted.