### PR TITLE
Add ability to declare modules that can be disabled

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -30,7 +30,8 @@ module Kafo
         :facts                => {},
         :low_priority_modules => [],
         :verbose_log_level    => 'notice',
-        :skip_puppet_version_check => false
+        :skip_puppet_version_check => false,
+        :disablable_modules   => nil,
     }
 
     def self.get_scenario_id(filename)

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -347,12 +347,7 @@ module Kafo
         request_help
       end
 
-      modules.each do |mod|
-        app_option d("--[no-]enable-#{mod.name}"),
-                   :flag,
-                   "Enable '#{mod.name}' puppet module",
-                   :default => mod.enabled?
-      end
+      set_enable_disable_module_options
 
       params.sort.each do |param|
         doc = param.doc.nil? ? 'UNDOCUMENTED' : param.doc.join("\n")
@@ -360,6 +355,24 @@ module Kafo
                           :multivalued => param.multivalued?
         app_option parametrize(param, 'reset-'), :flag,
                           "Reset #{param.name} to the default value (#{param.default_to_s})"
+      end
+    end
+
+    def set_enable_disable_module_options
+      if (disablable_modules = config.app[:disablable_modules])
+        modules.each do |mod|
+          if disablable_modules.include?(mod.name)
+            app_option d("--[no-]enable-#{mod.name}"), :flag, "Enable '#{mod.name}' puppet module",
+                       :default => mod.enabled?
+          elsif !mod.enabled?
+            app_option d("--enable-#{mod.name}"), :flag, "Enable '#{mod.name}' puppet module"
+          end
+        end
+      else
+        modules.each do |mod|
+          app_option d("--[no-]enable-#{mod.name}"), :flag, "Enable '#{mod.name}' puppet module",
+                     :default => mod.enabled?
+        end
       end
     end
 

--- a/test/fixtures/manifests/disabled_testing_module.pp
+++ b/test/fixtures/manifests/disabled_testing_module.pp
@@ -1,0 +1,2 @@
+# Simple module for testing disabled state
+class testing::disable_module_testing () {}


### PR DESCRIPTION
Modules in an answer file are assumed to be able to be enabled
and subsequently disabled. However, turning off a puppet module
entirely can produce negative affects for users depending on the
scenario.

This adds the ability to declare specifically the set of modules
that can be disabled. If any are declared (or an empty list) then
the available app options are adjusted. Any disabled module can be
will get a --enable option, any currently enabled option will not
have any option for enable or disable and any module declared in
the disablable modules list will get a --[no-]enable option for
turning it on and off.