### PR TITLE
Fixes #31269: Roll logs by date

### DIFF
--- a/lib/kafo/logging.rb
+++ b/lib/kafo/logging.rb
@@ -46,7 +46,8 @@ module Kafo
             level: log_level,
             filename: filename,
             layout: layout(color: false),
-            truncate: true
+            truncate: true,
+            roll_by: 'date'
           )
 
           FileUtils.chown(


### PR DESCRIPTION
After more than 5-10 runs of an installer, the log files lose all semblance of when they were run just looking at the log files. Someone debugging has to look inside the log files and piece together the timeline themselves. Switching to rolling by date and timestamp provides a clearer view of the order of log files, when each run of the installer was executed to pair with other system logs and how many times the installer was ran in some window of time.