### PR TITLE
Fixes #31304: set exit code before post hooks

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -465,7 +465,7 @@ module Kafo
         'show_diff' => true,
       )
 
-      exit_code   = 0
+      self.class.exit_handler.exit_code = 0
       exit_status = nil
       options     = [
           '--verbose',
@@ -493,12 +493,12 @@ module Kafo
                 Process.wait(pid)
               rescue Errno::ECHILD # process could exit meanwhile so we rescue
               end
-              exit_code = $?.exitstatus
+              self.class.exit_handler.exit_code = $?.exitstatus
             end
           end
         end
       rescue PTY::ChildExited => e # could be raised by Process.wait on older ruby or by PTY.check
-        exit_code = e.status.exitstatus
+        self.class.exit_handler.exit_code = e.status.exitstatus
       end
 
       @progress_bar.close if @progress_bar

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -283,5 +283,17 @@ module Kafo
         _(YAML.load_file(KAFO_CONFIG)[:color_of_background]).must_equal "dark"
       end
     end
+
+    describe 'exit codes' do
+      it 'exit code should be set before post hooks' do
+        code, stdout, err = run_command '../bin/kafo-configure'
+
+        _(stdout).must_include "2"
+
+        code, stdout, err = run_command '../bin/kafo-configure'
+
+        _(stdout).must_include "0"
+      end
+    end
   end
 end

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -51,6 +51,7 @@ def generate_installer
   config = YAML.load_file(KAFO_CONFIG)
   config[:log_dir] = INSTALLER_HOME
   File.open(KAFO_CONFIG, 'w') { |f| f.write(config.to_yaml) }
+  add_hooks
 end
 
 def add_manifest(name = 'basic')
@@ -71,4 +72,8 @@ end
 def add_metadata(name = 'basic')
   FileUtils.mkdir_p TEST_MODULE_PATH
   FileUtils.cp File.expand_path("../../fixtures/metadata/#{name}.json", __FILE__), File.join(TEST_MODULE_PATH, 'metadata.json')
+end
+
+def add_hooks
+  FileUtils.cp_r File.expand_path("../../fixtures/hooks", __FILE__), INSTALLER_HOME
 end

--- a/test/fixtures/hooks/post/10-exit-code.rb
+++ b/test/fixtures/hooks/post/10-exit-code.rb
@@ -1,0 +1,1 @@
+puts @kafo.exit_code


### PR DESCRIPTION
If the exit code is not set until the exit handler runs, post hooks
can incorrectly surmise the current exit code. The puppet run sets
the exit code after execution. Users of Kafo such as the foreman-installer
rely on the exit_code in some of the post hooks to determine behavior.