### PR TITLE
Drop simplecov coverage collection

### DIFF
--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-reporters'
-  spec.add_development_dependency 'simplecov'
 
   spec.add_dependency 'kafo_wizards'
   spec.add_dependency 'ansi'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,3 @@
-require 'simplecov'
-SimpleCov.start do
-  add_filter "/test/"
-end
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/mock'


### PR DESCRIPTION
We are both seeing errors in PRs intermittently and without clear explanation and we do not collect or measure this coverage data:

```
Using /usr/local/rvm/gems/ruby-2.6.3 with gemset jenkins-kafo-pr-test-206-2-2-6-5-0

** Invoke jenkins:unit (first_time)

** Invoke jenkins:setup (first_time)

** Execute jenkins:setup

** Invoke test:unit (first_time)

** Execute test:unit

/usr/local/rvm/rubies/ruby-2.6.3/bin/ruby -w -I"lib:lib:test" -I"/usr/local/rvm/gems/ruby-2.6.3@jenkins-kafo-pr-test-206-2-2-6-5-0/gems/rake-13.0.1/lib" "/usr/local/rvm/gems/ruby-2.6.3@jenkins-kafo-pr-test-206-2-2-6-5-0/gems/rake-13.0.1/lib/rake/rake_test_loader.rb" "test/kafo/color_scheme_test.rb" "test/kafo/condition_test.rb" "test/kafo/configuration_test.rb" "test/kafo/data_type_parser_test.rb" "test/kafo/data_type_test.rb" "test/kafo/data_types/any_test.rb" "test/kafo/data_types/array_test.rb" "test/kafo/data_types/boolean_test.rb" "test/kafo/data_types/enum_test.rb" "test/kafo/data_types/float_test.rb" "test/kafo/data_types/hash_test.rb" "test/kafo/data_types/integer_test.rb" "test/kafo/data_types/not_undef_test.rb" "test/kafo/data_types/numeric_test.rb" "test/kafo/data_types/optional_test.rb" "test/kafo/data_types/pattern_test.rb" "test/kafo/data_types/regexp_test.rb" "test/kafo/data_types/scalar_test.rb" "test/kafo/data_types/string_test.rb" "test/kafo/data_types/struct_test.rb" "test/kafo/data_types/tuple_test.rb" "test/kafo/data_types/type_reference_test.rb" "test/kafo/data_types/undef_test.rb" "test/kafo/data_types/variant_test.rb" "test/kafo/execution_environment_test.rb" "test/kafo/exit_handler_test.rb" "test/kafo/fact_writer_test.rb" "test/kafo/help_builders/advanced_test.rb" "test/kafo/help_builders/basic_test.rb" "test/kafo/hiera_configurer_test.rb" "test/kafo/hook_context_test.rb" "test/kafo/hooking_test.rb" "test/kafo/kafo_configure_test.rb" "test/kafo/logger_test.rb" "test/kafo/migration_context_test.rb" "test/kafo/migrations_test.rb" "test/kafo/param_test.rb" "test/kafo/parser_cache_reader_test.rb" "test/kafo/parser_cache_writer_test.rb" "test/kafo/progress_bar_test.rb" "test/kafo/puppet_command_test.rb" "test/kafo/puppet_configurer_test.rb" "test/kafo/puppet_log_parser_test.rb" "test/kafo/puppet_module_test.rb" "test/kafo/scenario_manager_test.rb" "test/kafo/store_test.rb" "test/kafo/system_check_test.rb" "test/kafo/wizard_test.rb" -v



File does not exist: simplecov



rake aborted!
```