### PR TITLE
Rename --verbose-log-level to --terminal-log-level

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -33,7 +33,7 @@ module Kafo
         :facts                => {},
         :low_priority_modules => [],
         :verbose              => false,
-        :verbose_log_level    => 'notice',
+        :terminal_log_level   => 'notice',
         :skip_puppet_version_check => false,
         :parser_cache_path    => nil,
         :ignore_undocumented  => nil,
@@ -173,7 +173,7 @@ module Kafo
     def migrate_configuration(from_config, options={})
       keys_to_skip = options.fetch(:skip, [])
       keys = [:log_dir, :log_name, :log_level, :no_prefix,
-        :colors, :color_of_background, :custom, :verbose_log_level]
+        :colors, :color_of_background, :custom, :terminal_log_level]
       keys += options.fetch(:with, [])
       keys.each do |key|
         next if keys_to_skip.include?(key)

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -333,7 +333,9 @@ module Kafo
                  :default => false, :advanced => true
       app_option ['-v', '--[no-]verbose'], :flag, 'Display log on STDOUT instead of progressbar',
                  :default => config.app[:verbose]
-      app_option ['-l', '--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
+      app_option ['--verbose-log-level'], 'LEVEL', 'Log level for verbose mode output',
+                 :default => 'notice', :hidden => true
+      app_option ['-l', '--terminal-log-level'], 'LEVEL', 'Log level for verbose mode terminal output',
                  :default => 'notice'
       app_option ['-S', '--scenario'], 'SCENARIO', 'Use installation scenario'
       app_option ['--disable-scenario'], 'SCENARIO', 'Disable installation scenario',

--- a/lib/kafo/logging.rb
+++ b/lib/kafo/logging.rb
@@ -28,7 +28,14 @@ module Kafo
           KafoConfigure.config.app[:log_owner],
           KafoConfigure.config.app[:log_group]
         )
-        setup_verbose(level: KafoConfigure.config.app[:verbose_log_level] || level) if verbose
+        verbose_log_level = KafoConfigure.config.app[:verbose_log_level]
+        terminal_log_level = KafoConfigure.config.app[:terminal_log_level]
+        if !verbose_log_level.nil?
+          STDERR.puts '--verbose-log-level is deprecated and will be removed. Please use --terminal-log-level instead.'
+          setup_verbose(level: verbose_log_level || level) if verbose
+        else
+          setup_verbose(level: terminal_log_level || level) if verbose
+        end
       end
 
       def setup_file_logging(log_level, log_dir, log_owner, log_group)

--- a/test/kafo/configuration_test.rb
+++ b/test/kafo/configuration_test.rb
@@ -101,7 +101,7 @@ module Kafo
     describe '#migrate_configuration' do
 
       let(:keys) { [:log_dir, :log_name, :log_level, :no_prefix,
-          :colors, :color_of_background, :custom, :verbose_log_level] }
+          :colors, :color_of_background, :custom, :terminal_log_level] }
 
       before do
         (keys + [:description]).each { |key| old_config.app[key] = 'old value' }


### PR DESCRIPTION
The name `--verbose-log-level` is ambiguous. The user could interpret this to mean that they are making logs more verbose, rather than terminal output, and may not realize it does nothing if they don't also pass `--verbose true`.

This PR aims to make this easier to understand by renaming it to `--terminal-log-level` to indicate it refers to the log level of terminal output. (`--stdout-log-level` may be a better name... I am open to suggestions).

The old `--verbose-log-level` option still exists and still functions, but it no longer has a default and now also prints a deprecation notice to stderr.