### PR TITLE
Fixes #31332: Do not display log output when using --help

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -143,7 +143,7 @@ module Kafo
       # so we limit parsing only to app config options (because of --help and later defined params)
       parse clamp_app_arguments
       parse_app_arguments # set values from ARGS to config.app
-      Logging.setup(verbose: config.app[:verbose])
+      Logging.setup(verbose: config.app[:verbose]) unless ARGV.any? { |option| ['--help', '--full-help'].include? option }
       self.class.set_color_scheme
 
       self.class.hooking.execute(:init)

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -18,6 +18,14 @@ module Kafo
         _(out).wont_include "--reset-"
         _(out).must_include "Use --full-help to view the complete list."
       end
+
+      it 'does not include log output with verbose mode' do
+        code, out, err = run_command '../bin/kafo-configure --help --verbose'
+        _(code).must_equal 0, err
+        _(out).must_include "Usage:"
+        _(out).wont_include "NOTICE"
+        _(out).wont_include "Executing hooks"
+      end
     end
 
     describe '--full-help' do
@@ -33,6 +41,14 @@ module Kafo
         _(out).must_match(/--testing-db-type\s*can be mysql or sqlite \(current: "mysql"\)/)
         _(out).must_match(/--reset-testing-db-type\s*Reset db_type to the default value \("mysql"\)/)
         _(out).wont_include "Use --full-help to view the complete list."
+      end
+
+      it 'does not include log output with verbose mode' do
+        code, out, err = run_command '../bin/kafo-configure --full-help --verbose'
+        _(code).must_equal 0, err
+        _(out).must_include "Usage:"
+        _(out).wont_include "NOTICE"
+        _(out).wont_include "Executing hooks"
       end
     end
 


### PR DESCRIPTION
Logs are buffered before logging configuration is set up, such that
once they are they are added to the log file and to the terminal
output when using verbose mode. That could be triggered when
running --help causing the user to see some log output which
is confusing when using --help. This skips log setup if --help
is present and also prevents new log files from being created
unnecessarily.