### PR TITLE
Fixes #30365 - Resolve symlinks to determine AIO Puppet

### DIFF
--- a/lib/kafo/puppet_command.rb
+++ b/lib/kafo/puppet_command.rb
@@ -43,8 +43,15 @@ module Kafo
       File.join([bin_path, bin_name].compact)
     end
 
+    def self.is_aio_puppet?
+      puppet_command = search_puppet_path('puppet')
+      File.realpath(puppet_command).start_with?('/opt/puppetlabs')
+    rescue Errno::ENOENT
+      false
+    end
+
     def self.format_command(command)
-      if search_puppet_path('puppet').start_with?('/opt/puppetlabs')
+      if is_aio_puppet?
         [clean_env_vars, command, :unsetenv_others => true]
       else
         [::ENV, command, :unsetenv_others => false]

--- a/test/kafo/puppet_command_test.rb
+++ b/test/kafo/puppet_command_test.rb
@@ -81,5 +81,45 @@ module Kafo
         specify { File.stub(:executable?, false) { _(pc).must_equal 'puppet' } }
       end
     end
+
+    describe '.is_aio_puppet?' do
+      subject do
+        PuppetCommand.stub(:format_command, puppet_command) do
+          PuppetCommand.is_aio_puppet?
+        end
+      end
+
+      describe 'with an absolute path' do
+        let(:puppet_command) { '/usr/bin/puppet' }
+
+        specify 'as a real file' do
+          File.stub(:realpath, ->(path) { path }) do
+            refute subject
+          end
+        end
+
+        specify 'as a symlink to AIO' do
+          File.stub(:realpath, '/opt/puppetlabs/puppet/bin/wrapper.sh') do
+            assert subject
+          end
+        end
+
+        specify 'as a broken symlink' do
+          File.stub(:realpath, ->(path) { raise Errno::ENOENT, 'No such file or directory' }) do
+            refute subject
+          end
+        end
+      end
+
+      describe 'with a relative path' do
+        let(:puppet_command) { 'puppet' }
+
+        specify 'non-existant' do
+          File.stub(:realpath, ->(path) { raise Errno::ENOENT, 'No such file or directory' }) do
+            refute subject
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Commit 695ad18f7f3dccb07d93604701f68345c665b181 attempted to deal with symlinks in /usr/bin or /usr/local/bin, but broke things because paths in /opt/puppetlabs/bin are also symlinks. That's why it was reverted in eacdf43c780ef5ac7fab90f0ce3d49b04539bba3.

This uses File.realpath to resolve symlinks so /usr/local/bin/puppet is fine as long as it is pointing to a file in /opt/puppetlabs.

I haven't had a chance to test this PR.