### PR TITLE
Fixes #31466: Switch HighLine back to using :info color

### DIFF
--- a/lib/kafo/scenario_manager.rb
+++ b/lib/kafo/scenario_manager.rb
@@ -31,7 +31,7 @@ module Kafo
     end
 
     def list_available_scenarios
-      say ::HighLine.color("Available scenarios", :notice)
+      say ::HighLine.color("Available scenarios", :info)
       available_scenarios.each do |config_file, content|
         scenario = File.basename(config_file, '.yaml')
         use = (File.expand_path(config_file) == @previous_scenario ? 'INSTALLED' : "use: --scenario #{scenario}")
@@ -111,7 +111,7 @@ module Kafo
     end
 
     def show_scenario_diff(prev_scenario, new_scenario)
-      say ::HighLine.color("Scenarios are being compared, that may take a while...", :notice)
+      say ::HighLine.color("Scenarios are being compared, that may take a while...", :info)
       prev_conf = load_and_setup_configuration(prev_scenario)
       new_conf = load_and_setup_configuration(new_scenario)
       print_scenario_diff(prev_conf, new_conf)

--- a/lib/kafo/wizard.rb
+++ b/lib/kafo/wizard.rb
@@ -68,7 +68,7 @@ END
 
     def display_hash
       data = Hash[@config.modules.map { |mod| [mod.name, mod.enabled? ? mod.params_hash : false] }]
-      say HighLine.color(YAML.dump(data), :notice)
+      say HighLine.color(YAML.dump(data), :info)
     end
 
     def configure_module(mod)
@@ -79,7 +79,7 @@ END
           menu.prompt = 'Choose an option from the menu... '
           menu.select_by = :index
 
-          menu.choice("Enable/disable #{mod.name} module, current value: #{HighLine.color(mod.enabled?.to_s, :notice)}") { turn_module(mod) }
+          menu.choice("Enable/disable #{mod.name} module, current value: #{HighLine.color(mod.enabled?.to_s, :info)}") { turn_module(mod) }
           if mod.enabled?
             render_params(mod.primary_parameter_group.params, menu)
 
@@ -114,7 +114,7 @@ END
     def render_params(params, menu)
       params.each do |param|
         if param.visible?(@kafo.params)
-          menu.choice "Set #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :notice)}" do
+          menu.choice "Set #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :info)}" do
             configure(param)
           end
         end
@@ -141,13 +141,13 @@ END
     end
 
     def configure_single(param)
-      say "\ncurrent value: #{HighLine.color(param.value_to_s, :notice)}"
+      say "\ncurrent value: #{HighLine.color(param.value_to_s, :info)}"
       ask("new value:")
     end
 
     def configure_multi(param)
-      say HighLine.color('every line is a separate value, blank line to quit, for hash use key:value syntax', :notice)
-      say "\ncurrent value: #{HighLine.color(param.value_to_s, :notice)} %>"
+      say HighLine.color('every line is a separate value, blank line to quit, for hash use key:value syntax', :info)
+      say "\ncurrent value: #{HighLine.color(param.value_to_s, :info)} %>"
       ask("new value:") do |q|
         q.gather = ""
       end
@@ -164,7 +164,7 @@ END
         say "\n" + HighLine.color("Resetting parameters of module #{mod.name}", :headline)
         choose do |menu|
           mod.params.each do |param|
-            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :notice)}, default value: #{HighLine.color(param.default_to_s, :notice)}" do
+            menu.choice "Reset #{HighLine.color(param.name, :important)}, current value: #{HighLine.color(param.value_to_s, :info)}, default value: #{HighLine.color(param.default_to_s, :info)}" do
               reset(param)
             end if param.visible?(@kafo.params)
           end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -52,6 +52,15 @@ module Kafo
       end
     end
 
+    describe '--list-scenarios' do
+      it 'lists scenarios' do
+        code, out, err = run_command '../bin/kafo-configure --list-scenarios --no-colors'
+        _(code).must_equal 0, err
+        _(out).must_include "Available scenarios"
+        _(out).must_include "default (use: --scenario default)"
+      end
+    end
+
     describe 'default args' do
       it 'must create file' do
         code, _, err = run_command '../bin/kafo-configure'


### PR DESCRIPTION
HighLine does not have a :notice color which was changed as part
of the switchover from info to notice as the default log level.