### PR TITLE
Fixes #31513: Sort hooks globally rather than within a hooks directory

### DIFF
--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -48,11 +48,17 @@ module Kafo
     def execute(group, log_stage: true)
       logger = Logger.new(group)
       logger.notice "Executing hooks in group #{group}" if log_stage
-      self.hooks[group].keys.sort_by(&:to_s).each do |name|
+
+      sorted_hooks = self.hooks[group].keys.sort do |a, b|
+        File.basename(a.to_s) <=> File.basename(b.to_s)
+      end
+
+      sorted_hooks.each do |name|
         hook = self.hooks[group][name]
         result = HookContext.execute(self.kafo, logger, &hook)
         logger.debug "Hook #{name} returned #{result.inspect}"
       end
+
       logger.notice "All hooks in group #{group} finished" if log_stage
       @group = nil
     end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -320,5 +320,13 @@ module Kafo
         _(stdout).must_include "0"
       end
     end
+
+    describe 'hooks ordering' do
+      it 'should execute hooks in globally sorted order' do
+        code, stdout, err = run_command '../bin/kafo-configure'
+
+        _(stdout).must_include "Runs before exit code hook in post\n2"
+      end
+    end
   end
 end

--- a/test/acceptance/test_helper.rb
+++ b/test/acceptance/test_helper.rb
@@ -50,6 +50,7 @@ def generate_installer
   run_command "kafofy -c #{KAFO_CONFIG_DIR}", :dir => TMPDIR
   config = YAML.load_file(KAFO_CONFIG)
   config[:log_dir] = INSTALLER_HOME
+  config[:hook_dirs] = ['hooks', 'additional_hooks']
   File.open(KAFO_CONFIG, 'w') { |f| f.write(config.to_yaml) }
   add_hooks
 end
@@ -76,4 +77,5 @@ end
 
 def add_hooks
   FileUtils.cp_r File.expand_path("../../fixtures/hooks", __FILE__), INSTALLER_HOME
+  FileUtils.cp_r File.expand_path("../../fixtures/additional_hooks", __FILE__), INSTALLER_HOME
 end

--- a/test/fixtures/additional_hooks/post/05-pre-exit-code.rb
+++ b/test/fixtures/additional_hooks/post/05-pre-exit-code.rb
@@ -1,0 +1,1 @@
+puts "Runs before exit code hook in post"


### PR DESCRIPTION
Prior to this change, hooks were sorted within a specified hooks directory
rather than globally across all hooks for a given stage. This means
that additional hooks provided could not insert themselves into
the overall ordering provided within the base hooks/ directory.