### PR TITLE
Release 6.2.1

### DIFF
--- a/lib/kafo/version.rb
+++ b/lib/kafo/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 module Kafo
   PARSER_CACHE_VERSION = 1
-  VERSION = "6.2.0"
+  VERSION = "6.2.1"
 end


### PR DESCRIPTION
This information is mostly useless for users. They fly by without
providing anything to act on. By downgrading them to info they do show
up in logs, but no longer in the default execution.