### PR TITLE
Fixes #32088 - Change configuration steps log message frequency and wording

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -198,7 +198,7 @@ module Kafo
           }
 EOS
 
-        @logger.notice 'Loading default values from puppet modules...'
+        @logger.info "Loading default values from puppet modules..."
         command = PuppetCommand.new(dump_manifest, [], puppetconf, self).command
         stdout, stderr, status = Open3.capture3(*PuppetCommand.format_command(command))
 
@@ -223,7 +223,7 @@ EOS
           end
         end
 
-        @logger.notice "... finished"
+        @logger.info "... finished loading default values from puppet modules."
 
         load_yaml_from_output(stdout.split($/))
       end

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -144,6 +144,7 @@ module Kafo
       parse clamp_app_arguments
       parse_app_arguments # set values from ARGS to config.app
       Logging.setup(verbose: config.app[:verbose]) unless ARGV.any? { |option| ['--help', '--full-help'].include? option }
+      logger.notice("Loading installer configuration. This will take some time.")
       self.class.set_color_scheme
 
       self.class.hooking.execute(:init)
@@ -440,7 +441,7 @@ module Kafo
     end
 
     def validate_all(logging = true)
-      logger.notice 'Running validation checks'
+      logger.info "Running validation checks."
       results = enabled_params.map do |param|
         result = param.valid?
         errors = param.validation_errors.join(', ')
@@ -493,8 +494,8 @@ HEREDOC
               progress_log(method, message, logger)
 
               if (output = line.match(%r{(.+\]): Starting to evaluate the resource( \((?<count>\d+) of (?<total>\d+)\))?}))
-                if (output[:count].to_i % 100) == 1 && output[:count].to_i != 1
-                  logger.notice("#{output[:count].to_i - 1} out of #{output[:total]} done.")
+                if (output[:count].to_i % 250) == 1 && output[:count].to_i != 1
+                  logger.notice("#{output[:count].to_i - 1} configuration steps out of #{output[:total]} steps complete.")
                 end
               end
 


### PR DESCRIPTION
This information should not be relevant to the user except in troubleshooting, so let's log it at level DEBUG which will hide it from the new default log based terminal output in standard operation