### PR TITLE
Fixes #32099: Check if an Integer for integer data_type 

### DIFF
--- a/lib/kafo/data_types/integer.rb
+++ b/lib/kafo/data_types/integer.rb
@@ -19,7 +19,9 @@ module Kafo
       end
 
       def typecast(value)
-        value =~ /\d+/ ? value.to_i : value
+        Integer(value)
+      rescue TypeError, ArgumentError
+        value
       end
 
       def valid?(input, errors = [])

--- a/lib/kafo/data_types/numeric.rb
+++ b/lib/kafo/data_types/numeric.rb
@@ -2,7 +2,9 @@ module Kafo
   module DataTypes
     class Numeric < DataType
       def typecast(value)
-        value =~ /\d+/ ? value.to_f : value
+        Float(value)
+      rescue TypeError, ArgumentError
+        value
       end
 
       def valid?(input, errors = [])

--- a/lib/kafo/exceptions.rb
+++ b/lib/kafo/exceptions.rb
@@ -8,7 +8,4 @@ module Kafo
 
   class ParserError < StandardError
   end
-
-  class TypeError < StandardError
-  end
 end

--- a/test/kafo/data_types/integer_test.rb
+++ b/test/kafo/data_types/integer_test.rb
@@ -17,7 +17,9 @@ module Kafo
       describe "#typecast" do
         it { _(Integer.new.typecast(1)).must_equal 1 }
         it { _(Integer.new.typecast('1')).must_equal 1 }
-        it { _(Integer.new.typecast('1foo')).must_equal 1 }
+        it { _(Integer.new.typecast('1.5')).must_equal '1.5' }
+        it { _(Integer.new.typecast(' 10 ')).must_equal 10 }
+        it { _(Integer.new.typecast('1foo')).must_equal '1foo' }
         it { _(Integer.new.typecast('foo')).must_equal 'foo' }
       end
 

--- a/test/kafo/data_types/numeric_test.rb
+++ b/test/kafo/data_types/numeric_test.rb
@@ -10,7 +10,7 @@ module Kafo
       describe "#typecast" do
         it { _(Numeric.new.typecast(1.1)).must_be_close_to 1.1 }
         it { _(Numeric.new.typecast('1.1')).must_be_close_to 1.1 }
-        it { _(Numeric.new.typecast('1foo')).must_be_close_to 1.0 }
+        it { _(Numeric.new.typecast('1foo')).must_equal '1foo' }
         it { _(Numeric.new.typecast('foo')).must_equal 'foo' }
       end
 


### PR DESCRIPTION
This fixes a deprecation warning present in Ruby 2.7:

warning: deprecated Object#=~ is called on Integer; it always returns nil