### PR TITLE
Fixes #32135: Find puppet module parser only when needed

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -130,7 +130,7 @@ module Kafo
     def modules
       @modules ||= begin
         register_data_types
-        @data.keys.map { |mod| PuppetModule.new(mod, PuppetModule.find_parser, self).parse }.sort
+        @data.keys.map { |mod| PuppetModule.new(mod, configuration: self).parse }.sort
       end
     end
 
@@ -159,7 +159,7 @@ module Kafo
     end
 
     def add_module(name)
-      mod = PuppetModule.new(name, PuppetModule.find_parser, self).parse
+      mod = PuppetModule.new(name, configuration: self).parse
       unless modules.map(&:name).include?(mod.name)
         mod.enable
         @modules << mod

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -25,7 +25,7 @@ module Kafo
       end
     end
 
-    def initialize(identifier, parser = self.class.find_parser, configuration = KafoConfigure.config)
+    def initialize(identifier, parser: nil, configuration: KafoConfigure.config)
       @identifier        = identifier
       @configuration     = configuration
       @name              = get_name
@@ -65,6 +65,7 @@ module Kafo
     def parse(builder_klass = ParamBuilder)
       @raw_data = @parser_cache.get(identifier, manifest_path) if @parser_cache
       if @raw_data.nil?
+        @parser = self.class.find_parser if @parser.nil?
         if @parser.nil? || @parser == :none
           raise ParserError.new("No Puppet module parser is installed and no cache of the file #{manifest_path} is available. Please check debug logs and install optional dependencies for the parser.")
         else

--- a/test/kafo/configuration_test.rb
+++ b/test/kafo/configuration_test.rb
@@ -161,7 +161,7 @@ module Kafo
 
     describe '#module' do
       it 'finds module by name' do
-        basic_config.stub(:modules, [PuppetModule.new('a', nil), PuppetModule.new('b', nil)]) do
+        basic_config.stub(:modules, [PuppetModule.new('a'), PuppetModule.new('b')]) do
           _(basic_config.module('b')).must_be_kind_of PuppetModule
           _(basic_config.module('c')).must_be_nil
         end

--- a/test/kafo/hiera_configurer_test.rb
+++ b/test/kafo/hiera_configurer_test.rb
@@ -6,7 +6,7 @@ module Kafo
     subject { HieraConfigurer }
 
     describe "#generate_data" do
-      let(:puppet_module) { @@puppet_module ||= PuppetModule.new('testing', TestParser.new(BASIC_MANIFEST)).tap { |m| m.enable }.parse }
+      let(:puppet_module) { @@puppet_module ||= PuppetModule.new('testing', parser: TestParser.new(BASIC_MANIFEST)).tap { |m| m.enable }.parse }
       specify { _(puppet_module.enabled?).must_equal true }
       specify { _(subject.generate_data([puppet_module])['classes']).must_equal ['testing'] }
       specify { _(subject.generate_data([puppet_module])['testing::version']).must_equal '1.0' }

--- a/test/kafo/parser_cache_reader_test.rb
+++ b/test/kafo/parser_cache_reader_test.rb
@@ -63,7 +63,7 @@ module Kafo
       end
 
       let(:parser) { TestParser.new(BASIC_MANIFEST) }
-      let(:mod) { PuppetModule.new('puppet', parser) }
+      let(:mod) { PuppetModule.new('puppet', parser: parser) }
       let(:writer) { ParserCacheWriter.write([mod]) }
       let(:cache) { ParserCacheFactory.build(writer) }
 

--- a/test/kafo/wizard_test.rb
+++ b/test/kafo/wizard_test.rb
@@ -11,7 +11,7 @@ module Kafo
     let(:output) { StringIO.new }
 
     let(:parser) { @@puppet_parser ||= TestParser.new(BASIC_MANIFEST) }
-    let(:puppet_module) { PuppetModule.new('puppet', parser).parse }
+    let(:puppet_module) { PuppetModule.new('puppet', parser: parser).parse }
 
     let(:kafo) do
       kafo                     = OpenStruct.new


### PR DESCRIPTION
Moves finding of the puppet module parser closer to when it's
actually needed such as no cache found. This saves around 0.5-1
seconds during execution.