### PR TITLE
Fixes #32136: Setup verbose logging only when help option is present

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -143,7 +143,13 @@ module Kafo
       # so we limit parsing only to app config options (because of --help and later defined params)
       parse clamp_app_arguments
       parse_app_arguments # set values from ARGS to config.app
-      Logging.setup(verbose: config.app[:verbose]) unless ARGV.any? { |option| ['--help', '--full-help'].include? option }
+
+      if ARGV.any? { |option| ['--help', '--full-help'].include? option }
+        Logging.setup_verbose(level: :error)
+      else
+        Logging.setup(verbose: config.app[:verbose])
+      end
+
       logger.notice("Loading installer configuration. This will take some time.")
       self.class.set_color_scheme
 


### PR DESCRIPTION
Users will not get any output if there is an error message running help, such
as when parsing Puppet default values. Further, the log file will
not have any information in it given we do not log to file when
using help to reduce log file sprawl. This will print anything
logged at error level when running help.

Using the situation that happened here in the foreman-installer here: https://github.com/theforeman/foreman-installer/pull/662
This would be the output with this change, which is more verbose than I think we should send to users, but I wanted to keep this change focused:

```
ehelms@wareagle foreman-installer (2.4-stable)$ bundle exec 2.5-6.0/sbin/foreman-installer --help --scenario foreman --verbose
Could not get default values, check log file at 2.5-6.0/var/log/foreman-installer/foreman.log for more information
2021-03-19 09:17:38 [ERROR ] [root] echo '
        $kafo_config_file="2.5-6.0/etc/foreman-installer/scenarios.d/foreman.yaml"
        $kafo_add_progress=true
                kafo_configure::puppet_version_semver { "puppetlabs-apache":
          requirement => ">= 5.5.10 < 8.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-apt":
          requirement => ">= 5.5.10 < 8.0.0",
        }

        kafo_configure::puppet_version_semver { "herculesteam-augeasproviders_core":
          requirement => ">= 5.0.0 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "herculesteam-augeasproviders_sysctl":
          requirement => ">= 5.0.0 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "katello-candlepin":
          requirement => ">= 5.5.20 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "katello-certs":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-concat":
          requirement => ">= 5.5.10 < 8.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-dhcp":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-dns":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppet-extlib":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-foreman":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-foreman_proxy":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "katello-foreman_proxy_content":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-git":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-inifile":
          requirement => ">= 5.5.10 < 8.0.0",
        }

        kafo_configure::puppet_version_semver { "katello-katello":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-postgresql":
          requirement => ">= 5.5.10 < 8.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-pulpcore":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-puppet":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "katello-qpid":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppet-redis":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-stdlib":
          requirement => ">= 5.5.10 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "camptocamp-systemd":
          requirement => ">= 4.10.10 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-tftp":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-translate":
          requirement => ">= 5.5.10 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppet-trusted_ca":
          requirement => ">= 5.5.8 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "puppetlabs-xinetd":
          requirement => ">= 4.7.1 < 7.0.0",
        }

        kafo_configure::puppet_version_semver { "theforeman-kafo_configure":
          requirement => ">= 4.5.0 < 7.0.0",
        }

                  include foreman::params include foreman::cli::params include foreman_proxy::params include puppet::params include foreman_proxy::plugin::ansible::params include foreman_proxy::plugin::chef::params include foreman_proxy::plugin::discovery::params include foreman_proxy::plugin::dynflow::params include foreman_proxy::plugin::salt::params
          class { '::kafo_configure::dump_values':
            lookups   => ["foreman::db_host","foreman::db_port","foreman::db_database","foreman::db_sslmode","foreman::db_root_cert","puppet::run_hour","puppet::run_minute","puppet::server_acceptor_threads","puppet::server_selector_threads","puppet::server_ssl_acceptor_threads","puppet::server_ssl_selector_threads","puppet::server_max_threads","puppet::server_versioned_code_id","puppet::server_versioned_code_content","foreman_proxy::plugin::dhcp::infoblox::username","foreman_proxy::plugin::dhcp::infoblox::password","foreman_proxy::plugin::dhcp::remote_isc::key_name","foreman_proxy::plugin::dhcp::remote_isc::key_secret","foreman_proxy::plugin::dns::infoblox::dns_server","foreman_proxy::plugin::dns::infoblox::username","foreman_proxy::plugin::dns::infoblox::password","foreman_proxy::plugin::monitoring::version","foreman_proxy::plugin::omaha::http_proxy","foreman_proxy::plugin::omaha::version","foreman_proxy::plugin::omaha::distribution","foreman_proxy::plugin::openscap::version","foreman_proxy::plugin::openscap::proxy_name"],
            variables => ["foreman::params::foreman_url","foreman::params::unattended","foreman::params::unattended_url","foreman::params::apache","foreman::params::passenger","foreman::params::passenger_ruby","foreman::params::passenger_ruby_package","foreman::params::plugin_prefix","foreman::params::servername","foreman::params::serveraliases","foreman::params::ssl","foreman::params::version","foreman::params::plugin_version","foreman::params::db_manage","foreman::params::db_username","foreman::params::db_password","foreman::params::db_pool","foreman::params::db_manage_rake","foreman::params::app_root","foreman::params::manage_user","foreman::params::user","foreman::params::group","foreman::params::user_groups","foreman::params::rails_env","foreman::params::vhost_priority","foreman::params::server_port","foreman::params::server_ssl_port","foreman::params::server_ssl_ca","foreman::params::server_ssl_chain","foreman::params::server_ssl_cert","foreman::params::server_ssl_certs_dir","foreman::params::server_ssl_key","foreman::params::server_ssl_crl","foreman::params::server_ssl_protocol","foreman::params::server_ssl_verify_client","foreman::params::client_ssl_ca","foreman::params::client_ssl_cert","foreman::params::client_ssl_key","foreman::params::oauth_active","foreman::params::oauth_map_users","foreman::params::oauth_consumer_key","foreman::params::oauth_consumer_secret","foreman::params::passenger_prestart","foreman::params::passenger_min_instances","foreman::params::passenger_start_timeout","foreman::params::initial_admin_username","foreman::params::initial_admin_password","foreman::params::initial_admin_first_name","foreman::params::initial_admin_last_name","foreman::params::initial_admin_email","foreman::params::initial_admin_locale","foreman::params::initial_admin_timezone","foreman::params::initial_organization","foreman::params::initial_location","foreman::params::ipa_authentication","foreman::params::http_keytab","foreman::params::pam_service","foreman::params::ipa_manage_sssd","foreman::params::websockets_encrypt","foreman::params::websockets_ssl_key","foreman::params::websockets_ssl_cert","foreman::params::logging_level","foreman::params::logging_type","foreman::params::logging_layout","foreman::params::loggers","foreman::params::email_delivery_method","foreman::params::email_smtp_address","foreman::params::email_smtp_port","foreman::params::email_smtp_domain","foreman::params::email_smtp_authentication","foreman::params::email_smtp_user_name","foreman::params::email_smtp_password","foreman::params::telemetry_prefix","foreman::params::telemetry_prometheus_enabled","foreman::params::telemetry_statsd_enabled","foreman::params::telemetry_statsd_host","foreman::params::telemetry_statsd_protocol","foreman::params::telemetry_logger_enabled","foreman::params::telemetry_logger_level","foreman::params::dynflow_pool_size","foreman::params::jobs_manage_service","foreman::params::jobs_service_ensure","foreman::params::jobs_service_enable","foreman::params::jobs_sidekiq_redis_url","foreman::params::hsts_enabled","foreman::params::cors_domains","foreman::params::foreman_service_puma_threads_min","foreman::params::foreman_service_puma_threads_max","foreman::params::foreman_service_puma_workers","foreman::params::rails_cache_store","foreman::params::keycloak","foreman::params::keycloak_app_name","foreman::params::keycloak_realm","foreman::cli::params::foreman_url","foreman::cli::params::version","foreman::cli::params::manage_root_config","foreman::cli::params::username","foreman::cli::params::password","foreman::cli::params::use_sessions","foreman::cli::params::refresh_cache","foreman::cli::params::request_timeout","foreman::cli::params::ssl_ca_file","foreman::cli::params::hammer_plugin_prefix","foreman_proxy::params::repo","foreman_proxy::params::gpgcheck","foreman_proxy::params::version","foreman_proxy::params::ensure_packages_version","foreman_proxy::params::bind_host","foreman_proxy::params::http_port","foreman_proxy::params::ssl_port","foreman_proxy::params::groups","foreman_proxy::params::log","foreman_proxy::params::log_level","foreman_proxy::params::log_buffer","foreman_proxy::params::log_buffer_errors","foreman_proxy::params::http","foreman_proxy::params::ssl","foreman_proxy::params::ssl_ca","foreman_proxy::params::ssl_cert","foreman_proxy::params::ssl_key","foreman_proxy::params::foreman_ssl_ca","foreman_proxy::params::foreman_ssl_cert","foreman_proxy::params::foreman_ssl_key","foreman_proxy::params::trusted_hosts","foreman_proxy::params::ssl_disabled_ciphers","foreman_proxy::params::tls_disabled_versions","foreman_proxy::params::manage_sudoersd","foreman_proxy::params::use_sudoersd","foreman_proxy::params::use_sudoers","foreman_proxy::params::puppetca","foreman_proxy::params::puppetca_listen_on","foreman_proxy::params::ssldir","foreman_proxy::params::puppetdir","foreman_proxy::params::puppetca_cmd","foreman_proxy::params::puppet_group","foreman_proxy::params::puppetca_provider","foreman_proxy::params::autosignfile","foreman_proxy::params::puppetca_sign_all","foreman_proxy::params::puppetca_tokens_file","foreman_proxy::params::puppetca_token_ttl","foreman_proxy::params::puppetca_certificate","foreman_proxy::params::manage_puppet_group","foreman_proxy::params::puppet","foreman_proxy::params::puppet_listen_on","foreman_proxy::params::puppet_url","foreman_proxy::params::ssl_ca","foreman_proxy::params::ssl_cert","foreman_proxy::params::ssl_key","foreman_proxy::params::puppet_api_timeout","foreman_proxy::params::templates","foreman_proxy::params::templates_listen_on","foreman_proxy::params::template_url","foreman_proxy::params::registration","foreman_proxy::params::registration_listen_on","foreman_proxy::params::logs","foreman_proxy::params::logs_listen_on","foreman_proxy::params::httpboot","foreman_proxy::params::httpboot_listen_on","foreman_proxy::params::tftp","foreman_proxy::params::tftp_listen_on","foreman_proxy::params::tftp_managed","foreman_proxy::params::tftp_manage_wget","foreman_proxy::params::tftp_syslinux_filenames","foreman_proxy::params::tftp_root","foreman_proxy::params::tftp_dirs","foreman_proxy::params::tftp_servername","foreman_proxy::params::tftp_replace_grub2_cfg","foreman_proxy::params::dhcp","foreman_proxy::params::dhcp_listen_on","foreman_proxy::params::dhcp_managed","foreman_proxy::params::dhcp_provider","foreman_proxy::params::dhcp_subnets","foreman_proxy::params::dhcp_ping_free_ip","foreman_proxy::params::dhcp_option_domain","foreman_proxy::params::dhcp_search_domains","foreman_proxy::params::dhcp_interface","foreman_proxy::params::dhcp_additional_interfaces","foreman_proxy::params::dhcp_gateway","foreman_proxy::params::dhcp_range","foreman_proxy::params::dhcp_pxeserver","foreman_proxy::params::dhcp_pxefilename","foreman_proxy::params::dhcp_network","foreman_proxy::params::dhcp_netmask","foreman_proxy::params::dhcp_nameservers","foreman_proxy::params::dhcp_server","foreman_proxy::params::dhcp_config","foreman_proxy::params::dhcp_leases","foreman_proxy::params::dhcp_key_name","foreman_proxy::params::dhcp_key_secret","foreman_proxy::params::dhcp_omapi_port","foreman_proxy::params::dhcp_peer_address","foreman_proxy::params::dhcp_node_type","foreman_proxy::params::dhcp_failover_address","foreman_proxy::params::dhcp_failover_port","foreman_proxy::params::dhcp_max_response_delay","foreman_proxy::params::dhcp_max_unacked_updates","foreman_proxy::params::dhcp_mclt","foreman_proxy::params::dhcp_load_split","foreman_proxy::params::dhcp_load_balance","foreman_proxy::params::dhcp_manage_acls","foreman_proxy::params::dns","foreman_proxy::params::dns_listen_on","foreman_proxy::params::dns_managed","foreman_proxy::params::dns_provider","foreman_proxy::params::dns_interface","foreman_proxy::params::dns_zone","foreman_proxy::params::dns_reverse","foreman_proxy::params::dns_server","foreman_proxy::params::dns_ttl","foreman_proxy::params::dns_tsig_keytab","foreman_proxy::params::dns_tsig_principal","foreman_proxy::params::dns_forwarders","foreman_proxy::params::libvirt_network","foreman_proxy::params::libvirt_connection","foreman_proxy::params::bmc","foreman_proxy::params::bmc_listen_on","foreman_proxy::params::bmc_default_provider","foreman_proxy::params::bmc_ssh_user","foreman_proxy::params::bmc_ssh_key","foreman_proxy::params::bmc_ssh_powerstatus","foreman_proxy::params::bmc_ssh_powercycle","foreman_proxy::params::bmc_ssh_poweroff","foreman_proxy::params::bmc_ssh_poweron","foreman_proxy::params::realm","foreman_proxy::params::realm_listen_on","foreman_proxy::params::realm_provider","foreman_proxy::params::realm_keytab","foreman_proxy::params::realm_principal","foreman_proxy::params::freeipa_config","foreman_proxy::params::freeipa_remove_dns","foreman_proxy::params::keyfile","foreman_proxy::params::register_in_foreman","foreman_proxy::params::foreman_base_url","foreman_proxy::params::registered_name","foreman_proxy::params::registered_proxy_url","foreman_proxy::params::oauth_effective_user","foreman_proxy::params::oauth_consumer_key","foreman_proxy::params::oauth_consumer_secret","puppet::params::version","puppet::params::user","puppet::params::group","puppet::params::dir","puppet::params::codedir","puppet::params::vardir","puppet::params::logdir","puppet::params::rundir","puppet::params::ssldir","puppet::params::sharedir","puppet::params::manage_packages","puppet::params::dir_owner","puppet::params::dir_group","puppet::params::package_provider","puppet::params::package_source","puppet::params::port","puppet::params::pluginsync","puppet::params::splay","puppet::params::splaylimit","puppet::params::autosign","puppet::params::autosign_entries","puppet::params::autosign_mode","puppet::params::autosign_content","puppet::params::autosign_source","puppet::params::runinterval","puppet::params::usecacheonfailure","puppet::params::runmode","puppet::params::unavailable_runmodes","puppet::params::cron_cmd","puppet::params::systemd_cmd","puppet::params::systemd_randomizeddelaysec","puppet::params::agent_noop","puppet::params::show_diff","puppet::params::module_repository","puppet::params::http_connect_timeout","puppet::params::http_read_timeout","puppet::params::ca_server","puppet::params::ca_port","puppet::params::ca_crl_filepath","puppet::params::prerun_command","puppet::params::postrun_command","puppet::params::dns_alt_names","puppet::params::use_srv_records","puppet::params::srv_domain","puppet::params::pluginsource","puppet::params::pluginfactsource","puppet::params::additional_settings","puppet::params::agent_additional_settings","puppet::params::agent_restart_command","puppet::params::classfile","puppet::params::hiera_config","puppet::params::auth_template","puppet::params::allow_any_crl_auth","puppet::params::auth_allowed","puppet::params::client_package","puppet::params::agent","puppet::params::remove_lock","puppet::params::report","puppet::params::client_certname","puppet::params::puppetmaster","puppet::params::systemd_unit_name","puppet::params::service_name","puppet::params::syslogfacility","puppet::params::environment","puppet::params::server","puppet::params::server_admin_api_whitelist","puppet::params::manage_user","puppet::params::user","puppet::params::group","puppet::params::dir","puppet::params::ip","puppet::params::port","puppet::params::server_ca","puppet::params::server_ca_crl_sync","puppet::params::server_crl_enable","puppet::params::server_ca_auth_required","puppet::params::server_ca_client_self_delete","puppet::params::server_ca_client_whitelist","puppet::params::server_custom_trusted_oid_mapping","puppet::params::server_http","puppet::params::server_http_port","puppet::params::server_reports","puppet::params::server_puppetserver_dir","puppet::params::server_puppetserver_vardir","puppet::params::server_puppetserver_rundir","puppet::params::server_puppetserver_logdir","puppet::params::server_puppetserver_version","puppet::params::server_external_nodes","puppet::params::server_trusted_external_command","puppet::params::server_cipher_suites","puppet::params::server_config_version","puppet::params::server_connect_timeout","puppet::params::server_git_repo","puppet::params::server_default_manifest","puppet::params::server_default_manifest_path","puppet::params::server_default_manifest_content","puppet::params::server_environments_owner","puppet::params::server_environments_group","puppet::params::server_environments_mode","puppet::params::server_envs_dir","puppet::params::server_envs_target","puppet::params::server_common_modules_path","puppet::params::server_git_repo_mode","puppet::params::server_git_repo_path","puppet::params::server_git_repo_group","puppet::params::server_git_repo_user","puppet::params::server_git_branch_map","puppet::params::server_idle_timeout","puppet::params::server_post_hook_content","puppet::params::server_post_hook_name","puppet::params::server_storeconfigs","puppet::params::server_ruby_load_paths","puppet::params::server_ssl_dir","puppet::params::server_ssl_dir_manage","puppet::params::server_ssl_key_manage","puppet::params::server_ssl_protocols","puppet::params::server_ssl_chain_filepath","puppet::params::server_package","puppet::params::server_version","puppet::params::server_certname","puppet::params::server_request_timeout","puppet::params::server_strict_variables","puppet::params::server_additional_settings","puppet::params::server_foreman","puppet::params::server_foreman_url","puppet::params::server_foreman_ssl_ca","puppet::params::server_foreman_ssl_cert","puppet::params::server_foreman_ssl_key","puppet::params::server_foreman_facts","puppet::params::server_puppet_basedir","puppet::params::server_parser","puppet::params::server_environment_timeout","puppet::params::server_jvm_java_bin","puppet::params::server_jvm_config","puppet::params::server_jvm_min_heap_size","puppet::params::server_jvm_max_heap_size","puppet::params::server_jvm_extra_args","puppet::params::server_jvm_cli_args","puppet::params::server_jruby_gem_home","puppet::params::server_max_active_instances","puppet::params::server_max_requests_per_instance","puppet::params::server_max_queued_requests","puppet::params::server_max_retry_delay","puppet::params::server_multithreaded","puppet::params::server_use_legacy_auth_conf","puppet::params::server_check_for_updates","puppet::params::server_environment_class_cache_enabled","puppet::params::server_allow_header_cert_info","puppet::params::server_web_idle_timeout","puppet::params::server_puppetserver_jruby9k","puppet::params::server_puppetserver_metrics","puppet::params::server_metrics_jmx_enable","puppet::params::server_metrics_graphite_enable","puppet::params::server_metrics_graphite_host","puppet::params::server_metrics_graphite_port","puppet::params::server_metrics_server_id","puppet::params::server_metrics_graphite_interval","puppet::params::server_metrics_allowed","puppet::params::server_puppetserver_experimental","puppet::params::server_puppetserver_auth_template","puppet::params::server_puppetserver_trusted_agents","puppet::params::server_puppetserver_trusted_certificate_extensions","puppet::params::server_compile_mode","puppet::params::server_ca_allow_sans","puppet::params::server_ca_allow_auth_extensions","puppet::params::server_ca_enable_infra_crl","puppet::params::server_max_open_files","foreman::params::client_ssl_ca","foreman::params::client_ssl_cert","foreman::params::client_ssl_key","foreman_proxy::plugin::ansible::params::enabled","foreman_proxy::plugin::ansible::params::listen_on","foreman_proxy::plugin::ansible::params::ansible_dir","foreman_proxy::plugin::ansible::params::working_dir","foreman_proxy::plugin::ansible::params::host_key_checking","foreman_proxy::plugin::ansible::params::stdout_callback","foreman_proxy::plugin::ansible::params::roles_path","foreman_proxy::plugin::ansible::params::ssh_args","foreman_proxy::plugin::ansible::params::install_runner","foreman_proxy::plugin::ansible::params::manage_runner_repo","foreman_proxy::plugin::chef::params::enabled","foreman_proxy::plugin::chef::params::listen_on","foreman_proxy::plugin::chef::params::version","foreman_proxy::plugin::chef::params::server_url","foreman_proxy::plugin::chef::params::client_name","foreman_proxy::plugin::chef::params::private_key","foreman_proxy::plugin::chef::params::ssl_verify","foreman_proxy::plugin::chef::params::ssl_pem_file","foreman_proxy::plugin::discovery::params::install_images","foreman_proxy::plugin::discovery::params::tftp_root","foreman_proxy::plugin::discovery::params::source_url","foreman_proxy::plugin::discovery::params::image_name","foreman_proxy::plugin::dynflow::params::enabled","foreman_proxy::plugin::dynflow::params::listen_on","foreman_proxy::plugin::dynflow::params::database_path","foreman_proxy::plugin::dynflow::params::console_auth","foreman_proxy::plugin::dynflow::params::core_listen","foreman_proxy::plugin::dynflow::params::core_port","foreman_proxy::plugin::dynflow::params::ssl_disabled_ciphers","foreman_proxy::plugin::dynflow::params::tls_disabled_versions","foreman_proxy::plugin::dynflow::params::open_file_limit","foreman_proxy::plugin::dynflow::params::external_core","foreman_proxy::plugin::salt::params::autosign_file","foreman_proxy::plugin::salt::params::enabled","foreman_proxy::plugin::salt::params::listen_on","foreman_proxy::plugin::salt::params::user","foreman_proxy::plugin::salt::params::api","foreman_proxy::plugin::salt::params::api_url","foreman_proxy::plugin::salt::params::api_auth","foreman_proxy::plugin::salt::params::api_username","foreman_proxy::plugin::salt::params::api_password","foreman_proxy::plugin::salt::params::saltfile"],
          }

      ' | RUBYLIB=/home/ehelms/workspace/upstream/foreman-installer/.bundle/ruby/2.7.0/gems/kafo-6.2.1/lib/kafo/../..//modules:/usr/share/gems/gems/bundler-2.1.4/lib /home/ehelms/workspace/upstream/foreman-installer/.bundle/ruby/2.7.0/bin/puppet apply --config=/tmp/kafo_installation20210319-1019106-cjxc65/puppet.conf 
2021-03-19 09:17:38 [ERROR ] [root] Warning: Could not retrieve fact servername
Error: Evaluation Error: Error while evaluating a Function Call, 'downcase' parameter 'arg' expects a value of type Numeric, String, Array, or Hash, got Undef (file: /home/ehelms/workspace/upstream/foreman-installer/2.5-6.0/share/foreman-installer/modules/foreman/manifests/params.pp, line: 3, column: 17) on node 

2021-03-19 09:17:38 [ERROR ] [root] Could not get default values, cannot continue
```