### PR TITLE
Support Puppet 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 if ENV['PUPPET_VERSION']
   gem 'puppet', "~> #{ENV['PUPPET_VERSION']}"
 else
-  gem 'puppet', '>= 4.5.0', '< 7.0.0'
+  gem 'puppet', '>= 4.5.0', '< 8.0.0'
 end
 
 gem 'puppet-strings', RUBY_VERSION >= '2.1' ? '>= 1.2.1' : '~> 1.2.1'

--- a/modules/kafo_configure/metadata.json
+++ b/modules/kafo_configure/metadata.json
@@ -9,7 +9,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.5.0 < 7.0.0"
+      "version_requirement": ">= 4.5.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
Without the metadata.json change kafo_configure fails with

```
Puppet 7.5.0 does not meet requirements for theforeman-kafo_configure (>= 4.5.0 < 7.0.0)
Cannot continue due to incompatible version of Puppet. Use --skip-puppet-version-check to disable this check.
```

when trying to run a Kafo-based installer. Gemfile changes may be needed elsewhere, not sure.