### PR TITLE
Fixes #32530: Enable passing a block to app_option for validations

### DIFF
--- a/lib/kafo/hook_context.rb
+++ b/lib/kafo/hook_context.rb
@@ -34,8 +34,8 @@ module Kafo
     #
     # @example
     #   app_option ['-n', '--noop'], :flag, 'Run puppet in noop mode?', :default => false
-    def app_option(*args)
-      self.kafo.class.app_option(*args)
+    def app_option(*args, &block)
+      self.kafo.class.app_option(*args, &block)
     end
 
     # Returns whether the given app option exists. This is useful when there's a conditional option that is


### PR DESCRIPTION
The clamp API for options allows passing a block to perform validations
on the incoming value. This opens up this ability to options defined
within hooks.