### PR TITLE
Fixes #32549: Implement multi hooks

### DIFF
--- a/lib/kafo/hooking.rb
+++ b/lib/kafo/hooking.rb
@@ -1,4 +1,5 @@
 require 'kafo/hook_context'
+require 'kafo/multi_stage_hook'
 
 module Kafo
   class Hooking
@@ -36,6 +37,14 @@ module Kafo
             register(hook_type, file, &hook_block)
           end
         end
+
+        # Multi stage hooks are special
+        Dir.glob(File.join(base_dir, 'multi', '*.rb')).sort.each do |file|
+          logger.debug "Loading multi stage hook #{file}"
+          hook = File.read(file)
+          MultiStageHook.new(file, self, TYPES).instance_eval(hook, file, 1)
+        end
+
         @loaded = true
       end
       self

--- a/lib/kafo/multi_stage_hook.rb
+++ b/lib/kafo/multi_stage_hook.rb
@@ -1,0 +1,13 @@
+module Kafo
+  class MultiStageHook
+    def initialize(name, registry, types)
+      default_name = name
+
+      types.each do |hook_type|
+        self.class.send(:define_method, hook_type) do |name=nil, &block|
+          registry.send(:register, hook_type, name || default_name, &block)
+        end
+      end
+    end
+  end
+end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -332,5 +332,13 @@ module Kafo
         _(stdout).must_include "Runs before exit code hook in post\n2"
       end
     end
+
+    describe 'multi-stage hooks' do
+      it 'should execute multi-stage hooks' do
+        code, stdout, err = run_command '../bin/kafo-configure --print-hello-kafo'
+
+        _(stdout).must_include "Hello Kafo\nGoodbye"
+      end
+    end
   end
 end

--- a/test/fixtures/hooks/multi/10-print_hello_kafo.rb
+++ b/test/fixtures/hooks/multi/10-print_hello_kafo.rb
@@ -1,0 +1,13 @@
+boot do
+  app_option('--print-hello-kafo', :flag, 'Prints Hello Kafo when run is complete')
+end
+
+post('11-print_goodbye') do
+  puts "Goodbye"
+end
+
+post do
+  if app_value(:print_hello_kafo)
+    puts "Hello Kafo"
+  end
+end


### PR DESCRIPTION
Multi hooks are a special hook that allow you to define multiple hook
stages within a single file. This can to avoid duplication of things
like constants.

This takes over https://github.com/theforeman/kafo/pull/288 and add tests and documentation. Besides what I have added is there anything else you'd like to see?