### PR TITLE
Add new configuration option for puppet classes

### DIFF
--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -135,13 +135,21 @@ module Kafo
         @data.map do |name, values|
           if (class_config = app[:classes][name.to_sym])
             can_disable = class_config[:can_disable] || false
+            excluded_params = class_config[:exclude] || []
           else
             can_disable = true
+            excluded_params = []
           end
 
           enabled = !!values || values.is_a?(Hash)
 
-          puppet_mod = PuppetModule.new(name, configuration: self, enabled: enabled, can_disable: can_disable)
+          puppet_mod = PuppetModule.new(
+            name,
+            configuration: self,
+            enabled: enabled,
+            can_disable: can_disable,
+            excluded_params: excluded_params
+          )
           puppet_mod.parse
         end.sort
       end

--- a/lib/kafo/configuration.rb
+++ b/lib/kafo/configuration.rb
@@ -43,6 +43,7 @@ module Kafo
       ScenarioOption::KAFO_MODULES_DIR          => nil,
       ScenarioOption::CONFIG_HEADER_FILE        => nil,
       ScenarioOption::DONT_SAVE_ANSWERS         => nil,
+      ScenarioOption::CLASSES                   => {},
     }
 
     def self.get_scenario_id(filename)
@@ -132,8 +133,15 @@ module Kafo
         register_data_types
 
         @data.map do |name, values|
+          if (class_config = app[:classes][name.to_sym])
+            can_disable = class_config[:can_disable] || false
+          else
+            can_disable = true
+          end
+
           enabled = !!values || values.is_a?(Hash)
-          puppet_mod = PuppetModule.new(name, configuration: self, enabled: enabled)
+
+          puppet_mod = PuppetModule.new(name, configuration: self, enabled: enabled, can_disable: can_disable)
           puppet_mod.parse
         end.sort
       end

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -388,8 +388,11 @@ module Kafo
       end
 
       modules.each do |mod|
-        app_option d("--[no-]enable-#{mod.name}"), :flag, "Enable '#{mod.name}' puppet module",
-                   :default => mod.enabled?
+        if mod.can_disable?
+          app_option d("--[no-]enable-#{mod.name}"), :flag, "Enable '#{mod.name}' puppet module (current: #{mod.enabled?})", :default => mod.enabled?
+        elsif !mod.enabled?
+          app_option d("--enable-#{mod.name}"), :flag, "Enable '#{mod.name}' puppet module (current: #{mod.enabled?})"
+        end
       end
 
       params.sort.each do |param|

--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -396,6 +396,7 @@ module Kafo
       end
 
       params.sort.each do |param|
+        next if param.module.excluded_param?(dashize(param.name))
         doc = param.doc.nil? ? 'UNDOCUMENTED' : param.doc.join("\n")
         app_option parametrize(param), '', doc + " (current: #{param.value_to_s})",
                    :multivalued => param.multivalued?

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -25,7 +25,7 @@ module Kafo
       end
     end
 
-    def initialize(identifier, parser: nil, configuration: KafoConfigure.config, enabled: nil, can_disable: true)
+    def initialize(identifier, parser: nil, configuration: KafoConfigure.config, enabled: nil, can_disable: true, excluded_params: [])
       @identifier        = identifier
       @configuration     = configuration
       @name              = get_name
@@ -49,6 +49,7 @@ module Kafo
       @raw_data          = nil
       @enabled           = enabled
       @can_disable       = can_disable
+      @excluded_params   = excluded_params
     end
 
     def enabled?
@@ -101,6 +102,10 @@ module Kafo
 
     def params_hash
       Hash[params.map { |param| [param.name, param.value] }]
+    end
+
+    def excluded_param?(param)
+      @excluded_params.include?(param)
     end
 
     def <=>(other)

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -25,7 +25,7 @@ module Kafo
       end
     end
 
-    def initialize(identifier, parser: nil, configuration: KafoConfigure.config, enabled: nil)
+    def initialize(identifier, parser: nil, configuration: KafoConfigure.config, enabled: nil, can_disable: true)
       @identifier        = identifier
       @configuration     = configuration
       @name              = get_name
@@ -48,13 +48,19 @@ module Kafo
       @params_class_name = get_params_class_name
       @raw_data          = nil
       @enabled           = enabled
+      @can_disable       = can_disable
     end
 
     def enabled?
       @enabled
     end
 
+    def can_disable?
+      @can_disable
+    end
+
     def disable
+      return unless can_disable?
       @enabled = false
     end
 

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -25,7 +25,7 @@ module Kafo
       end
     end
 
-    def initialize(identifier, parser: nil, configuration: KafoConfigure.config)
+    def initialize(identifier, parser: nil, configuration: KafoConfigure.config, enabled: nil)
       @identifier        = identifier
       @configuration     = configuration
       @name              = get_name
@@ -47,11 +47,11 @@ module Kafo
       @params_path       = get_params_path
       @params_class_name = get_params_class_name
       @raw_data          = nil
-      @enabled           = nil
+      @enabled           = enabled
     end
 
     def enabled?
-      @enabled.nil? ? @enabled = @configuration.module_enabled?(self) : @enabled
+      @enabled
     end
 
     def disable

--- a/lib/kafo/scenario_option.rb
+++ b/lib/kafo/scenario_option.rb
@@ -88,5 +88,7 @@ module Kafo
     # implements checks to verify this is correct with the Puppet version
     # that's running. This can be used to bypass the checks
     SKIP_PUPPET_VERSION_CHECK = :skip_puppet_version_check
+
+    CLASSES = :classes
   end
 end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -376,6 +376,18 @@ module Kafo
         _(code).must_equal 0, err
         _(out).must_include "--enable-testing"
       end
+
+      it 'allows declaring parameters that should be excluded as command line options' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:classes] = {:testing => {:exclude => ['version']}}
+        File.open(KAFO_CONFIG, 'w') do |file|
+          file.write(config.to_yaml)
+        end
+
+        code, out, err = run_command '../bin/kafo-configure --full-help'
+        _(code).must_equal 0, err
+        _(out).wont_include "--testing-version"
+      end
     end
   end
 end

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -340,5 +340,42 @@ module Kafo
         _(stdout).must_include "Hello Kafo\nGoodbye"
       end
     end
+
+    describe 'with classes' do
+      it 'includes enable flag by default' do
+        code, out, err = run_command '../bin/kafo-configure --help'
+        _(code).must_equal 0, err
+        _(out).must_include "--[no-]enable-testing"
+      end
+
+      it 'does not show disable flag if class cannot be disabled' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:classes] = {:testing => {:can_disable => false}}
+        File.open(KAFO_CONFIG, 'w') do |file|
+          file.write(config.to_yaml)
+        end
+
+        code, out, err = run_command '../bin/kafo-configure --help'
+        _(code).must_equal 0, err
+        _(out).wont_include "--[no-]enable-testing"
+      end
+
+      it 'shows enable flag if class is disabled' do
+        config = YAML.load_file(KAFO_CONFIG)
+        config[:classes] = {:testing => {:can_disable => false}}
+        File.open(KAFO_CONFIG, 'w') do |file|
+          file.write(config.to_yaml)
+        end
+
+        answers = {'testing' => false}
+        File.open(KAFO_ANSWERS, 'w') do |file|
+          file.write(answers.to_yaml)
+        end
+
+        code, out, err = run_command '../bin/kafo-configure --help'
+        _(code).must_equal 0, err
+        _(out).must_include "--enable-testing"
+      end
+    end
   end
 end

--- a/test/kafo/configuration_test.rb
+++ b/test/kafo/configuration_test.rb
@@ -76,10 +76,8 @@ module Kafo
     describe '#params_missing' do
       it 'lists all the params that are missing in the new config' do
         basic_config.stub(:modules, [fake_module('mod', [p_foo, p_bar])]) do
-          basic_config.stub(:module_enabled?, true) do
-            old_config.stub(:modules, [fake_module('mod', [p_old_foo, p_old_baz])]) do
-              _(basic_config.params_missing(old_config)).must_equal([p_old_baz])
-            end
+          old_config.stub(:modules, [fake_module('mod', [p_old_foo, p_old_baz])]) do
+            _(basic_config.params_missing(old_config)).must_equal([p_old_baz])
           end
         end
       end

--- a/test/kafo/puppet_module_test.rb
+++ b/test/kafo/puppet_module_test.rb
@@ -7,7 +7,7 @@ module Kafo
     end
 
     let(:parser) { TestParser.new(BASIC_MANIFEST) }
-    let(:mod) { PuppetModule.new 'puppet', parser: parser }
+    let(:mod) { PuppetModule.new 'puppet', parser: parser, enabled: true }
 
     describe "#enabled?" do
       specify { _(mod.enabled?).must_equal true }

--- a/test/kafo/scenario_manager_test.rb
+++ b/test/kafo/scenario_manager_test.rb
@@ -330,10 +330,8 @@ module Kafo
       it 'prints values that will be lost' do
         old_config.stub(:modules, [fake_module('mod', [p_old_baz])]) do
           new_config.stub(:modules, []) do
-            new_config.stub(:module_enabled?, true) do
-              manager.print_scenario_diff(old_config, new_config)
-              must_be_on_stdout(output, "mod::baz: 100\n")
-            end
+            manager.print_scenario_diff(old_config, new_config)
+            must_be_on_stdout(output, "mod::baz: 100\n")
           end
         end
       end

--- a/test/kafo/wizard_test.rb
+++ b/test/kafo/wizard_test.rb
@@ -11,7 +11,7 @@ module Kafo
     let(:output) { StringIO.new }
 
     let(:parser) { @@puppet_parser ||= TestParser.new(BASIC_MANIFEST) }
-    let(:puppet_module) { PuppetModule.new('puppet', parser: parser).parse }
+    let(:puppet_module) { PuppetModule.new('puppet', parser: parser, enabled: true).parse }
 
     let(:kafo) do
       kafo                     = OpenStruct.new


### PR DESCRIPTION
This builds on the initial proposal from this RFC (https://community.theforeman.org/t/defaulting-puppet-to-off-in-the-katello-scenario/14553) and further thoughts within the RFC (https://community.theforeman.org/t/defaulting-puppet-to-off-in-the-katello-scenario/14553/8).

This approach is to apply the idea of keeping scenario configuration separated from the parameter value storage. The benefits and aim of this solution over a complete version 2 answer file is:

 1) This change is progressive and backwards compatible. Scenarios can add this new section to the configuration file and take advantage of the new features.
 2) This model allows adding new features over time as new keys can be added to the configuration hash (e.g. include params, controlling enablement state)
 3) By keeping this in the configuration file, the answers file can remain in standard hiera yaml format. This means no custom backend or manipulation of the parameters in the answers file to allow the hiera hierarchy to continue to work. 
 4) This change is much smaller than an over haul to add support for a V2 answer file would be and thus the risk is much lower to existing projects.


The initial features this adds are:

 1) Ability to specify if a puppet class should be presented to the user as something than can be disabled. If `can_disable` is set to false, the user is never presented with a configuration option to disable it.
 2) Ability to specify parameters that should not be presented to a user as a CLI option. Then the scenario can hide parameters that either clutter the help output or are not meant to be configured by a user in an installer setup.

Example: Set foreman to not be able to disable and exclude the version and db_manage parameter:

```
:classes:
  :foreman:
    :can_disable: false
    :exclude:
      - version
      - db-manage
```

** Why a dedicated `can_disable` flag instead of a multi-state `enabled` field (e.g. true/false/always) ?

Attempting to use a single field for enabled did not easily cover all the states we need. Those being:

 * Puppet class is enabled by default, but can be disabled
 * Puppet class is disabled by default, can be enabled and then later disabled
 * Puppet class is enabled by default but cannot be disabled
 * Puppet class is disabled by default, can be enabled but once enabled cannot be disabled

The last condition here not being covered by the original RFC proposal of using 'always'. This separate field let's us build the entire matrix of states and cleanly separates the state (enabled/disabled) and capability (can be disabled).

** Why not add an `include` field right now?

Since all parameters are included by default, we need only to currently specify which parameters to exclude.