### PR TITLE
Break params into three distinct files

### DIFF
--- a/lib/kafo/param.rb
+++ b/lib/kafo/param.rb
@@ -7,7 +7,7 @@ module Kafo
     UNSET_VALUES = ['UNSET', :undef]
 
     attr_reader :name, :module, :type, :manifest_default
-    attr_accessor :doc, :value_set, :condition
+    attr_accessor :doc, :value_set, :condition, :user_value
     attr_writer :groups
 
     def initialize(builder, name, type)

--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -97,6 +97,16 @@ module Kafo
       Hash[params.map { |param| [param.name, param.value] }]
     end
 
+    def default_params_hash
+      Hash[params.map { |param| [param.name, param.default] }]
+    end
+
+    def user_params_hash
+      return false unless enabled?
+      user_params = params.reject { |param| param.user_value.nil? }
+      Hash[user_params.map { |param| [param.name, param.user_value] }]
+    end
+
     def <=>(other)
       @configuration.app[:low_priority_modules].each do |module_name|
         return 1 if self.name.include?(module_name) && !other.name.include?(module_name)

--- a/lib/kafo/scenario_option.rb
+++ b/lib/kafo/scenario_option.rb
@@ -12,6 +12,18 @@ module Kafo
     # Path to answer file, if the file does not exist a $pwd/config/answers.yaml is used as a fallback
     ANSWER_FILE = :answer_file
 
+    # Hash containing different params files and their paths
+    PARAMS_FILES = :params_files
+
+    # Path to file that will store the default params
+    DEFAULT_PARAMS_FILE = :default_params_file
+
+    # Path to file that will store the user input params from the CLI
+    USER_PARAMS_FILE = :user_params_file
+
+    # Path to file that will store the user input params from the CLI
+    SCENARIO_DEFAULT_PARAMS_FILE = :scenario_default_params_file
+
     # Enable colors? If you don't touch this, we'll autodetect terminal capabilities
     COLORS = :colors
     # Color scheme, we support :bright and :dark (first is better for white background, dark for black background)


### PR DESCRIPTION
### Concept

Instead of storing user input, scenario defaults and puppet defaults into a single mashed up file, let's store each of those distinct layer in their own files. That allows cleaner knowledge of what the value at each layer is, cleaner changes of each layer, and the ability for a given scenario to adapt each layer into the hiera heirarchy at it's discretion. Further, this opens the door to having a file that users to edit and manage directly with input as the user input file can be read early in the loading process (not yet implemented) prior to validations.

### Risk

This design is intended to be progressive and backwards compatible. Scenarios could opt to take advantage of this new layout style and moved away from the answers file method. Further, a toggle could be added (e.g. version: 2) to the configuration file to indicate a desire to use only the 3-layer approach rather than the answers file. While in the interim, this would support generating the 3-layers while keeping the answer file.

Users could end up with classes and params defined in the user input params file that no longer exist. The code could take the approach of removing any unknown classes and params and logging a warning to the user of what was removed.

### Upgrades

There is a question of what happens when a user has come to rely on the functionality currently provided by a default and on upgrade this default value changes. Let's take the example from (https://github.com/theforeman/foreman-installer/blob/develop/config/katello.migrations/210323145816-foreman-tasks-backup.rb) where the default for tasks back changed from true to false. On upgrade, we would want users to retain the previous configuration in case they were relying on the functionality. A few options:

 * Accept that defaults may change, and release notes should be identifying changes, often changes go unnoticed by users already
 * Log any changed defaults for the user to see and take action on
 * Prompt user with any default changes and let them decide what to do
 * Create a diff from the previous defaults and the new defaults and include that in the hiera heiarchy (though this defeats the notion of easily picking up new defaults)
 * Provide a way to specify a file of parameters when upgrading that sits just above defaults but is only applicable when not performing a first time install
 * Provide a way to specify parameters that should be migrated to the user input file so that changes in behavior that should be kept with the old value on upgrade are treated as the users new default

### Design

This adds a configuration file option to specify 3 params files: default puppet params, scenario default params, user input params.

#### Default Puppet Prams

Kafo will generate all of the default params coming from the Puppet layer and write them to a file on each installer run. This creates a file that represents the Puppet params that can be layered into the hiera heirarchy, and will change as defaults change or data coming from the system changes (e.g. if FQDN changes or CPU count changes).

#### Scenario Default Params

This file would be similar to an un-populated answers file. This file would define the defaults, what is enabled, what are default configurations that the scenario wants to set. By being a "static" file, one not overwritten by Kafo itself, the scenario could use hiera lookups to define some default parameters directly in this file.

#### User Input Params

This file would contain any input that the user supplies to override parameters. This would be from the CLI inputs and could potentially include direct edits to the file that is loaded early in the process for validations. If a user's input value matches a default value or scenario default the value would be removed from the user input params to help keep user input params as only things being overriden.

### Upgrading to 3-layer approach from answers file

To move from answers_file to 3-layer approach is largely about being able to discern the user input present in the answers file. The approach taken here is to effectively calculate puppet defaults, subtract them from the answers file. Then, subtract the scenario default options from the answers file and what is leftover should be user inputs. Given defaults from puppet could have changed, or scenario defaults could have changed, this would treat effectively all differences as user inputs. The plus side is that it would keep the continuity of the configuration and users could analyze the user input file and remove any they wanted handled by defaults.

### Other Benefits

#### Reduced Need for Migrations

This model, given it calculates and produces defaults on each run separately would prevent the need to have any migrations that reset parameters because the default changed. Examples:

 * https://github.com/theforeman/foreman-installer/blob/develop/config/katello.migrations/210809133829-reset-puma-min-threads.rb
 * https://github.com/theforeman/foreman-installer/blob/develop/config/katello.migrations/210802145222-reset-foreman-proxy-httpboot-undef.rb
 * https://github.com/theforeman/foreman-installer/blob/develop/config/katello.migrations/210726184347-clear-puppet-server-ssl-chain-filepath.rb

Migrations that puppet classes plugins would no longer be needed as they can be added directly to the scenario default params, examples that owuld not be needed:

 * https://github.com/theforeman/foreman-installer/blob/develop/config/katello.migrations/210723145429-add-webhooks-cli.rb
 * https://github.com/theforeman/foreman-installer/blob/develop/config/katello.migrations/210708144422-add-foreman-puppet.rb



