### PR TITLE
Ensure buffered log messages contain the proper timestamp

### DIFF
--- a/lib/kafo/logger.rb
+++ b/lib/kafo/logger.rb
@@ -13,7 +13,13 @@ module Kafo
 
     def log(level, *args, &block)
       if Logging.buffering?
-        Logging.to_buffer(@name, level, args, &block)
+        if block_given?
+          data = yield
+        else
+          data = args
+        end
+
+        Logging.to_buffer(@name, ::Logging::LogEvent.new(@name, ::Logging::LEVELS[level.to_s], data, false))
       else
         Logging.dump_buffer if Logging.dump_needed?
         @logger.send(level, *args, &block)

--- a/lib/kafo/logging.rb
+++ b/lib/kafo/logging.rb
@@ -118,7 +118,7 @@ module Kafo
 
       def dump_buffer
         @buffer.each do |log|
-          ::Logging.logger[log[0]].send(log[1], *([log[2]].flatten(2)), &log[3])
+          ::Logging.logger[log[0]].send(:log_event, log[1])
         end
         @buffer.clear
       end


### PR DESCRIPTION
Before logging is configured, log messages are stored in an internal
buffer to be dumped at the point at which logging is configured. At
the time the message was being dumped the timestamp was being calculated
making it appear as if a set of log messages all happened at the same
time. This gave no sense that those initial log messages and operations
might be taking long time in some cases.

This moves to storing those buffered messages as LogEvent's that
capture the time of creation such that when those messages are then
dumped to the logs they contain the timestamp of when the message
was actually created rather than the timestamp of when the message
was dumped.