### PR TITLE
Include manifest path in fatal error

### DIFF
--- a/lib/kafo/puppet_module.rb
+++ b/lib/kafo/puppet_module.rb
@@ -81,7 +81,7 @@ module Kafo
 
       self
     rescue ConfigurationException => e
-      @logger.fatal "Unable to continue because of: #{e.message}"
+      @logger.fatal "Unable to parse #{manifest_path} because of: #{e.message}"
       KafoConfigure.exit(:manifest_error)
     end
 


### PR DESCRIPTION
In a script it's much more useful if the filename is present.