### PR TITLE
Add method MigrationContext.keep_migration

### DIFF
--- a/lib/kafo/migration_context.rb
+++ b/lib/kafo/migration_context.rb
@@ -8,7 +8,7 @@ module Kafo
     def self.execute(migration_name, scenario, answers, &migration)
       context = new(migration_name, scenario, answers)
       context.instance_eval(&migration)
-      return context.scenario, context.answers
+      return context.scenario, context.answers, context.keep_migration?
     end
 
     def initialize(migration_name, scenario, answers)
@@ -30,8 +30,25 @@ module Kafo
       @migration_name
     end
 
+    def self.keep_migration?
+      keep_migration?
+    end
+
+    def self.keep_migration
+      logger.debug "Migration #{migration_name} has been marked for keeping. "\
+      "It may update configuration and answers, but it will not be written to "\
+      "applied migrations."
+      @keep_migration = true
+    end
+
+    private
+
     def logger
       @logger
+    end
+
+    def keep_migration?
+      !!@keep_migration
     end
   end
 end

--- a/lib/kafo/migration_context.rb
+++ b/lib/kafo/migration_context.rb
@@ -3,21 +3,35 @@ require 'kafo/base_context'
 module Kafo
   class MigrationContext < BaseContext
 
-    attr_accessor :scenario, :answers
+    attr_accessor :migration_name, :scenario, :answers
 
-    def self.execute(scenario, answers, &migration)
-      context = new(scenario, answers)
+    def self.execute(migration_name, scenario, answers, &migration)
+      context = new(migration_name, scenario, answers)
       context.instance_eval(&migration)
       return context.scenario, context.answers
     end
 
-    def initialize(scenario, answers)
+    def initialize(migration_name, scenario, answers)
+      @migration_name = migration_name
       @scenario = scenario
       @answers = answers
     end
 
+    def self.logger
+      # Allows us to defer initializing logger or updating its name
+      # until MigrationContext.logger is called. This is useful
+      # because most migrations do not log internal state.
+      logger ||= Kafo::Logger.new(self.migration_name)
+      logger.name = migration_name if (logger.name != migration_name)
+      logger
+    end
+
+    def self.migration_name
+      @migration_name
+    end
+
     def logger
-      KafoConfigure.logger
+      @logger
     end
   end
 end

--- a/lib/kafo/migrations.rb
+++ b/lib/kafo/migrations.rb
@@ -32,11 +32,12 @@ module Kafo
     end
 
     def run(scenario, answers)
-      @migrations.keys.sort.each do |name|
-        KafoConfigure.logger.debug "Executing migration #{name}"
-        migration = @migrations[name]
-        scenario, answers = Kafo::MigrationContext.execute(scenario, answers, &migration)
-        applied << File.basename(name.to_s)
+      @migrations.keys.sort.each do |filename|
+        short_name = File.basename(filename.to_s)
+        KafoConfigure.logger.debug "Executing migration: #{scenario[:name]}::#{short_name}"
+        migration = @migrations[filename]
+        scenario, answers = Kafo::MigrationContext.execute(short_name, scenario, answers, &migration)
+        applied << short_name
       end
       return scenario, answers
     end

--- a/lib/kafo/migrations.rb
+++ b/lib/kafo/migrations.rb
@@ -36,10 +36,10 @@ module Kafo
         short_name = File.basename(filename.to_s)
         KafoConfigure.logger.debug "Executing migration: #{scenario[:name]}::#{short_name}"
         migration = @migrations[filename]
-        scenario, answers = Kafo::MigrationContext.execute(short_name, scenario, answers, &migration)
-        applied << short_name
+        scenario, answers, keep_migration = Kafo::MigrationContext.execute(short_name, scenario, answers, &migration)
+        applied << short_name unless keep_migration
       end
-      return scenario, answers
+      scenario, answers
     end
 
     def store_applied

--- a/test/dummy_logger.rb
+++ b/test/dummy_logger.rb
@@ -1,8 +1,12 @@
 class DummyLogger
+
+  attr_accessor :name
+
   LEVELS = %w(fatal error warn info debug)
 
-  def initialize
+  def initialize(name = 'DummyLogger')
     LEVELS.each { |l| instance_variable_set("@#{l}", StringIO.new) }
+    @name = name
   end
 
   LEVELS.each do |level|
@@ -18,9 +22,5 @@ class DummyLogger
 
   def dump_errors
     true
-  end
-
-  def name
-    'DummyLogger'
   end
 end

--- a/test/kafo/migration_context_test.rb
+++ b/test/kafo/migration_context_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Kafo
   describe MigrationContext do
-    let(:context) { MigrationContext.new({}, {}) }
+    let(:context) { MigrationContext.new("DummyMigration", {}, {}) }
 
     before(:each) { MigrationContext.clear_caches }
 
@@ -10,6 +10,7 @@ module Kafo
       specify { context.respond_to?(:logger) }
       specify { context.respond_to?(:scenario) }
       specify { context.respond_to?(:answers) }
+      specify { context.respond_to?(:migration_name) }
       specify { context.respond_to?(:facts) }
     end
 

--- a/test/kafo/migrations_test.rb
+++ b/test/kafo/migrations_test.rb
@@ -3,24 +3,34 @@ require 'test_helper'
 module Kafo
   describe Migrations do
     let(:migrations) { Migrations.new('some_directory') }
-    let(:dummy_logger) { DummyLogger.new }
+    let(:kafo_configure_logger) { DummyLogger.new('KafoConfigureLogger') }
+    let(:migration_context) { MigrationContext.new('previous_migration', {}, {}) }
 
     describe '#run' do
 
       before do
-        KafoConfigure.logger = dummy_logger
-        migrations.add_migration('no1') { logger.error 's1' }
-        migrations.add_migration('no2') { logger.error 's2' }
+        KafoConfigure.logger = kafo_configure_logger
+        migrations.add_migration('m1') do
+          self.logger.error "#{logger.name} - s1"
+        end
+        migrations.add_migration('m2') do
+          self.logger.error "#{logger.name} - s2"
+        end
         migrations.run({}, {})
       end
 
-      it 'executes all the migrations' do
-        dummy_logger.rewind
-        _(dummy_logger.error.read).must_match(/.*s1.*s2.*/m)
+      it 'executes all the migrations and logs to MigrationContext logger' do
+        migration_context_logger.rewind
+        _(migration_context_logger.error.read).must_match(/.*m1.*s1.*m2.*s2.*/m)
+      end
+
+      it 'MigrationContext does not log to KafoConfigure.logger' do
+        kafo_configure_logger.rewind
+        !_(kafo_configure_logger.error.read).must_match(/.*s1.*s2.*/m)
       end
 
       it 'knows the applied migrations' do
-        _(migrations.applied).must_equal ['no1', 'no2']
+        _(migrations.applied).must_equal ['m1', 'm2']
       end
     end
   end

--- a/test/kafo/migrations_test.rb
+++ b/test/kafo/migrations_test.rb
@@ -4,7 +4,7 @@ module Kafo
   describe Migrations do
     let(:migrations) { Migrations.new('some_directory') }
     let(:kafo_configure_logger) { DummyLogger.new('KafoConfigureLogger') }
-    let(:migration_context) { MigrationContext.new('previous_migration', {}, {}) }
+    let(:migration_context) { MigrationContext.new('some_migration', {}, {}) }
 
     describe '#run' do
 
@@ -12,9 +12,16 @@ module Kafo
         KafoConfigure.logger = kafo_configure_logger
         migrations.add_migration('m1') do
           self.logger.error "#{logger.name} - s1"
+          self.logger.error "NOBODY_HOME"
         end
         migrations.add_migration('m2') do
           self.logger.error "#{logger.name} - s2"
+          self.logger.error "NOBODY_HOME"
+        end
+        migrations.add_migration('m3') do
+          self.keep_migration
+          self.logger.error "#{logger.name} - s3"
+          self.logger.error "NOBODY_HOME"
         end
         migrations.run({}, {})
       end
@@ -24,12 +31,17 @@ module Kafo
         _(migration_context_logger.error.read).must_match(/.*m1.*s1.*m2.*s2.*/m)
       end
 
-      it 'MigrationContext does not log to KafoConfigure.logger' do
-        kafo_configure_logger.rewind
-        !_(kafo_configure_logger.error.read).must_match(/.*s1.*s2.*/m)
+      it 'logs kept migration message to m3 logger' do
+        migration_context_logger.rewind
+        _(migration_context_logger.debug.read).must_match(/.*marked for keeping.*/m)
       end
 
-      it 'knows the applied migrations' do
+      it 'does not log to KafoConfigure.logger' do
+        kafo_configure_logger.rewind
+        !_(kafo_configure_logger.error.read).must_match(/.*NOBODY_HOME.*/m)
+      end
+
+      it 'knows the applied and unapplied migrations' do
         _(migrations.applied).must_equal ['m1', 'm2']
       end
     end


### PR DESCRIPTION
Such a migration may alter configuration and answers, or it may noop, but is not required to be recorded in applied migrations and may run more than once, until some condition is met. One simple application would be a backwards compatible migration that noops until a certain target version is reached.

Work in progress, builds on https://github.com/theforeman/kafo/pull/347