### PR TITLE
Fixes #34991: Use UTF-8 encoding when parsing data types

### DIFF
--- a/lib/kafo/data_type_parser.rb
+++ b/lib/kafo/data_type_parser.rb
@@ -10,7 +10,7 @@ module Kafo
       @logger = KafoConfigure.logger
       @types = {}
       manifest.each_line do |line|
-        if (type = TYPE_DEFINITION.match(line))
+        if (type = TYPE_DEFINITION.match(line.force_encoding("UTF-8")))
           @types[type[1]] = type[2]
         end
       end


### PR DESCRIPTION
Non US-ASCII characters can be used in types. For example, as
seen in puppet-systemd:

https://github.com/voxpupuli/puppet-systemd/commit/94d73491eedf28356c2d736738cbd97251cd5653