### PR TITLE
Store puppet_report as an instance variable

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -36,13 +36,14 @@ module Kafo
   class KafoConfigure < Clamp::Command
     include StringHelper
 
+    attr_accessor :puppet_report
+
     class << self
       include AppOption::Declaration
 
       attr_accessor :config, :root_dir, :config_file, :gem_root,
                     :module_dirs, :kafo_modules_dir, :verbose, :logger,
-                    :check_dirs, :exit_handler, :scenario_manager, :store,
-                    :puppet_report
+                    :check_dirs, :exit_handler, :scenario_manager, :store
       attr_writer :hooking
 
       def hooking
@@ -224,10 +225,6 @@ module Kafo
 
     def exit_code
       self.class.exit_code
-    end
-
-    def puppet_report
-      self.class.puppet_report
     end
 
     def help
@@ -552,7 +549,7 @@ module Kafo
       if (last_report = execution_env.reports.last)
         # For debugging: you can easily copy the last report to fixtures
         # FileUtils.cp(last_report, File.join(__dir__, '..', '..', 'test', 'fixtures', 'reports', File.basename(last_report)))
-        self.class.puppet_report = PuppetReport.load_report_file(last_report)
+        self.puppet_report = PuppetReport.load_report_file(last_report)
       end
 
       self.class.hooking.execute(:post)

--- a/test/kafo/kafo_configure_test.rb
+++ b/test/kafo/kafo_configure_test.rb
@@ -29,23 +29,5 @@ module Kafo
         _(KafoConfigure.use_colors?).must_equal false
       end
     end
-
-    describe '#puppet_report' do
-
-      before { KafoConfigure.puppet_report = report }
-      after { KafoConfigure.puppet_report = nil }
-
-      describe 'without a report' do
-        let(:report) { nil }
-
-        specify { assert_nil KafoConfigure.puppet_report }
-      end
-
-      describe 'with a report' do
-        let(:report) { PuppetReport.new({ 'report_format' => 11 }) }
-
-        specify { assert_equal(report, KafoConfigure.puppet_report) }
-      end
-    end
   end
 end


### PR DESCRIPTION
Somehow it wasn't working and storing it as an instance variable is cleaner anyway.

Found via https://github.com/theforeman/foreman-installer/pull/878

Fixes: 0612410091e7c74f8493fbaec1df9a516451018a ("Make Puppet reports available from the ExecEnv")