### PR TITLE
Expose the log messages by source on failed Puppet resources

### DIFF
--- a/lib/kafo/puppet_failed_resource.rb
+++ b/lib/kafo/puppet_failed_resource.rb
@@ -49,5 +49,20 @@ module Kafo
     def log_messages
       @logs.map { |log| log['message'] }
     end
+
+    # A collection of Puppet log messages grouped by source
+    #
+    # The log messages include detailed information of what failed. Some debug
+    # information, such as timing but crucially the command output, both stdout
+    # and stderr.
+    #
+    # A resource can have multiple sources. For example, exec can have both
+    # unless and returns. Combining the output of those can be confusing, so
+    # this presents them separate.
+    #
+    # @return [Hash[String, Array[String]]] The Puppet log messages for this resource
+    def log_messages_by_source
+      @logs.group_by { |log| log['source'] }.transform_values { |logs| logs.map { |log| log['message'] } }
+    end
   end
 end

--- a/lib/kafo/puppet_failed_resource.rb
+++ b/lib/kafo/puppet_failed_resource.rb
@@ -1,8 +1,5 @@
 module Kafo
   class PuppetFailedResource
-    # @return [Hash] The logs from this resource, directly from the Puppet report
-    attr_reader :logs
-
     # @param [Hash] status
     #   The status hash from the report
     # @param [Array[Hash]] logs


### PR DESCRIPTION
The previous log_messages combines the various sources of a resource, which makes things confusing. This new method still doesn't expose too much of the original report, which doesn't leak implementation details.