### PR TITLE
Fixes #36912 - support multi-line type definitions

### DIFF
--- a/lib/kafo/data_type_parser.rb
+++ b/lib/kafo/data_type_parser.rb
@@ -8,9 +8,26 @@ module Kafo
 
     def initialize(manifest)
       @logger = KafoConfigure.logger
-      @types = {}
+
+      lines = []
+      type_line_without_newlines = +''
       manifest.each_line do |line|
-        if (type = TYPE_DEFINITION.match(line.force_encoding("UTF-8")))
+        line = line.force_encoding("UTF-8").strip
+        next if line.start_with?('#')
+
+        line = line.split(' #').first.strip
+        if line =~ TYPE_DEFINITION
+          lines << type_line_without_newlines
+          type_line_without_newlines = line
+        else
+          type_line_without_newlines << line
+        end
+      end
+      lines << type_line_without_newlines
+
+      @types = {}
+      lines.each do |line|
+        if (type = TYPE_DEFINITION.match(line))
           @types[type[1]] = type[2]
         end
       end

--- a/test/kafo/data_type_test.rb
+++ b/test/kafo/data_type_test.rb
@@ -62,6 +62,11 @@ module Kafo
         _(DataType.new_from_string('Example[1,Float, /(regexp)/, Enum["foo", \'bar\'],-2]')).must_equal 'instance'
       end
 
+      it 'instantiates type with trailing comma' do
+        data_type.expect(:new, 'instance', ['1', 'Float'])
+        _(DataType.new_from_string('Example[1,Float,]')).must_equal 'instance'
+      end
+
       it 'instantiates type with multiple nested arguments' do
         data_type.expect(:new, 'instance', ['Hash[String, String]', 'Hash[String, String]'])
         _(DataType.new_from_string('Example[Hash[String, String], Hash[String, String]]')).must_equal 'instance'


### PR DESCRIPTION
This strips line breaks from type definitions, thus making them parseable again.

This will probably horribly break if type manifests would contain anything else but type definitions, but Puppet recommends [1] to store them in separate files and only have one type alias per file.

[1] https://www.puppet.com/docs/puppet/7/lang_type_aliases