### PR TITLE
Provide a dummy task in CI for the whole suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -11,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-    
+
   rubocop:
     name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
@@ -32,7 +33,7 @@ jobs:
             puppet: '8'
     env:
       PUPPET_VERSION: ${{ matrix.puppet }}
-      
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,3 +47,10 @@ jobs:
       - name: Run tests
         run: |
           bundle exec rake test test:acceptance
+
+  suite:
+    name: Test suite
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo Test suite completed


### PR DESCRIPTION
This task depends on the matrix tests so we can set it as a required task, rather than listing the whole matrix individually.