### PR TITLE
Add an option run checks only and exit

### DIFF
--- a/lib/kafo/kafo_configure.rb
+++ b/lib/kafo/kafo_configure.rb
@@ -193,12 +193,17 @@ module Kafo
         @progress_bar = config.app[:colors] ? ProgressBars::Colored.new : ProgressBars::BlackWhite.new
       end
 
-      unless skip_checks_i_know_better?
-        unless SystemChecker.check
-          puts "Your system does not meet configuration criteria"
+      if checks_only? || !skip_checks_i_know_better?
+        logger = Logger.new('checks')
+        if SystemChecker.check
+          logger.notice("System checks passed")
+        else
+          logger.error("Your system does not meet configuration criteria")
           self.class.exit(:invalid_system)
         end
       end
+
+      self.class.exit(0) if checks_only?
 
       self.class.hooking.execute(:pre_validations)
       if interactive?
@@ -362,6 +367,8 @@ module Kafo
       app_option ['-p', '--profile'], :flag, 'Run puppet in profile mode?',
                  :default => false, :advanced => true
       app_option ['-s', '--skip-checks-i-know-better'], :flag, 'Skip all system checks',
+                 :default => false
+      app_option ['--checks-only'], :flag, 'Run only system checks and exit',
                  :default => false
       app_option ['--skip-puppet-version-check'], :flag, 'Skip check for compatible Puppet versions',
                  :default => false, :advanced => true

--- a/test/acceptance/kafo_configure_test.rb
+++ b/test/acceptance/kafo_configure_test.rb
@@ -66,6 +66,24 @@ module Kafo
       end
     end
 
+    describe '--checks-only' do
+      it 'runs only checks and exits' do
+        FileUtils.mkdir_p "#{INSTALLER_HOME}/checks"
+        FileUtils.cp File.expand_path('../../fixtures/checks/pass/pass.sh', __FILE__), "#{INSTALLER_HOME}/checks"
+        code, out, err = run_command '../bin/kafo-configure --checks-only --verbose --no-colors'
+        _(code).must_equal 0, err
+        _(out).must_include "[checks] System checks passed"
+      end
+
+      it 'runs only checks and exits with failure for failing checks' do
+        FileUtils.mkdir_p "#{INSTALLER_HOME}/checks"
+        FileUtils.cp File.expand_path('../../fixtures/checks/fail/fail.sh', __FILE__), "#{INSTALLER_HOME}/checks"
+        code, out, err = run_command '../bin/kafo-configure --checks-only --verbose --no-colors'
+        _(code.exitstatus).must_equal 20, err
+        _(out).must_include "[checks] Your system does not meet configuration criteria"
+      end
+    end
+
     describe 'default args' do
       it 'must create file' do
         code, _, err = run_command '../bin/kafo-configure'
@@ -82,7 +100,7 @@ module Kafo
       end
 
       it 'must fail if system checks fail' do
-        FileUtils.mkdir "#{INSTALLER_HOME}/checks"
+        FileUtils.mkdir_p "#{INSTALLER_HOME}/checks"
         FileUtils.cp File.expand_path('../../fixtures/checks/fail/fail.sh', __FILE__), "#{INSTALLER_HOME}/checks"
         code, _, err = run_command '../bin/kafo-configure'
         _(code.exitstatus).must_equal 20, err


### PR DESCRIPTION
The intent is to at least allow two scenarios:

 1. Users that want to be able to run checks before committing to a full install
 2. Allowing foreman-maintain to run the installer checks as part of it's health checks rather than re-implementing the checks