### PR TITLE
Protect parsing of data types from empty lines

### DIFF
--- a/lib/kafo/data_type_parser.rb
+++ b/lib/kafo/data_type_parser.rb
@@ -13,7 +13,7 @@ module Kafo
       type_line_without_newlines = +''
       manifest.each_line do |line|
         line = line.force_encoding("UTF-8").strip
-        next if line.start_with?('#')
+        next if line.start_with?('#') || line.empty?
 
         line = line.split(' #').first.strip
         if line =~ TYPE_DEFINITION

--- a/test/kafo/data_type_parser_test.rb
+++ b/test/kafo/data_type_parser_test.rb
@@ -48,6 +48,11 @@ module Kafo
       it { _(parser.types).must_equal({"IP"=>"Variant[IPv4,IPv6,]", "IPProto"=>"Variant[TCP,UDP,]"}) }
     end
 
+    describe "parse multiple multiline aliases with empty lines" do
+      let(:file) { "# We need IP\n  \ntype IP = Variant[\n\n  IPv4, # Legacy IP\n\n  IPv6,\n\n]\n\n# We also need IPProto\n\ntype IPProto = Variant[\n\n  TCP,\n\n  UDP,\n\n]" }
+      it { _(parser.types).must_equal({"IP"=>"Variant[IPv4,IPv6,]", "IPProto"=>"Variant[TCP,UDP,]"}) }
+    end
+
     describe "#register" do
       after { DataType.unregister_type('Test') }
       let(:file) { 'type Test = String' }


### PR DESCRIPTION
If parsing empty rows in data type files the method first returns an nil class so strip doesn't work anymore. 