### PR TITLE
excape HTML entities (<>&") in HTML and Markdown output

### DIFF
--- a/bin/kafo-export-params
+++ b/bin/kafo-export-params
@@ -9,6 +9,7 @@ require 'kafo/parser_cache_writer'
 require 'kafo/string_helper'
 require 'logger'
 require 'yaml'
+require 'cgi'
 
 KafoConfigure = OpenStruct.new
 def KafoConfigure.exit(code)
@@ -76,9 +77,10 @@ module Kafo
 
         @config.modules.sort.each do |mod|
           mod.params.sort.each do |param|
+            html_doc = CGI.escapeHTML(param.doc.join(' '))
             puts '      <tr>'
             puts "        <td style='white-space:nowrap'>#{parametrize(param)}</td>"
-            puts "        <td>#{param.doc.join(' ')}</td>"
+            puts "        <td>#{html_doc}</td>"
             puts '      </tr>'
           end
         end
@@ -129,7 +131,8 @@ module Kafo
         puts "| #{'-'*40} | #{'-' * @max} |"
         @config.modules.sort.each do |mod|
           mod.params.sort.each do |param|
-            puts "| #{parametrize(param).ljust(40)} | #{param.doc.join(' ').ljust(@max)} |"
+            html_doc = CGI.escapeHTML(param.doc.join(' '))
+            puts "| #{parametrize(param).ljust(40)} | #{html_doc.ljust(@max)} |"
           end
         end
       end

--- a/test/acceptance/kafo_export_params_test.rb
+++ b/test/acceptance/kafo_export_params_test.rb
@@ -43,6 +43,7 @@ module Kafo
         it 'must output markdown' do
           _(command[1]).must_match(/\| Parameter name\s*\| Description\s*\|/)
           _(command[1]).must_match(/\| --testing-db-type\s*\| can be mysql or sqlite\s*\|/)
+          _(command[1]).must_include '&lt;List of IPs&gt;'
         end
       end
 
@@ -52,6 +53,7 @@ module Kafo
           _(command[1]).must_include '<th>Option</th>'
           _(command[1]).must_match %r{<td.*>--testing-db-type</td>}
           _(command[1]).must_include '<td>can be mysql or sqlite</td>'
+          _(command[1]).must_include '&lt;List of IPs&gt;'
         end
       end
 

--- a/test/fixtures/manifests/basic.pp
+++ b/test/fixtures/manifests/basic.pp
@@ -11,6 +11,11 @@
 #                    consisting of 3 lines
 # $typed::           something having it's type explicitly set
 # $multivalue::      list of users
+# $complex_variant:: A Variant type that can be:
+#                    String with:
+#                    '' or 'unmanaged' - Host auth control done elsewhere
+#                    'ip <List of IPs>' - Allowed IPs/ranges
+#                    Array of strings with ip or host as above
 # === Advanced parameters
 #
 # $debug::           we have advanced parameter, yay!
@@ -43,6 +48,7 @@ class testing(
   $username = 'root',
   Sensitive[String[1]] $password = Sensitive('supersecret'),
   Integer $pool_size = 10,
+  Optional[Variant[String, Array]] $complex_variant = undef,
   $file = undef,
   $base_dir = undef) {
 


### PR DESCRIPTION
Otherwise params that use those (esp <>) break the rendering of the HTML
output. And because Markdown can contain raw HTML at any place, we
escape it there too.
