### PR TITLE
force libdir to be part of our execution environment

### DIFF
--- a/lib/kafo/execution_environment.rb
+++ b/lib/kafo/execution_environment.rb
@@ -19,6 +19,10 @@ module Kafo
       end
     end
 
+    def libdir
+      @libdir ||= File.join(directory, 'lib')
+    end
+
     def reportdir
       @reportdir ||= File.join(directory, 'reports')
     end
@@ -46,8 +50,9 @@ module Kafo
         'environmentpath' => environmentpath,
         'factpath'        => factpath,
         'hiera_config'    => hiera_config,
-        'reports'         => 'store',
+        'libdir'          => libdir,
         'reportdir'       => reportdir,
+        'reports'         => 'store',
       }.merge(settings)
 
       PuppetConfigurer.new(puppet_conf, settings)


### PR DESCRIPTION
When the kafo is executed on a system that itself is a client to a Puppet
server, plugins that got synced (using pluginsync) from said server into
/opt/puppetlabs/puppet/cache/lib/ are picked up instead of the ones in
the configured modules dir under certain circumstances.

For example, puppetlabs-postgresql changed the postgresql_conf provider
from "parsed" to "ruby" in 10.0. If the parsed provider is present in
/opt/puppetlabs/puppet/cache/lib/ it gets used, instead of the new ruby
one, but the calling code (being from puppetlabs-postgresql 10+) doesn't
expect that and fails to properly (yet silently!) configure PostgreSQL.
