### PR TITLE
Add Ruby 3.3 / 3.4 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,10 @@ jobs:
             puppet: '7'
           - ruby: '3.2'
             puppet: '8'
+          - ruby: '3.3'
+            puppet: '8'
+          - ruby: '3.4'
+            puppet: '8'
     env:
       PUPPET_VERSION: ${{ matrix.puppet }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,9 @@ gem 'puppet-strings', '>= 1.2.1'
 # Do not pull in Psych 4 since it's incompatible with Puppet
 gem 'rdoc', '< 6.4' if RUBY_VERSION < '3.1'
 
+  # In Ruby 3.4, the gem could moved from default gems to bundled gems and need to be listed explicitly
+gem 'syslog' if RUBY_VERSION >= '3.4'
+
 group :puppet_module do
   gem 'metadata-json-lint'
   gem 'puppetlabs_spec_helper'

--- a/lib/kafo/data_types/struct.rb
+++ b/lib/kafo/data_types/struct.rb
@@ -5,10 +5,12 @@ module Kafo
         @spec = ::Hash[spec.map do |k,v|
           begin
             k = DataType.new_from_string(k)
-          rescue ConfigurationException; end
+          rescue ConfigurationException
+          end
           begin
             v = DataType.new_from_string(v)
-          rescue ConfigurationException; end
+          rescue ConfigurationException
+          end
           [k, v]
         end]
       end


### PR DESCRIPTION
highline 3.0.1 removed the abbrev dependency. This was once a core lib, which was moved to a normal gem in Ruby 3.4. highline 2 still uses it. That means on Ruby 3.4 we need to either add abbrev or update highline.

See https://github.com/search?q=repo%3AJEG2%2Fhighline%20abbrev&type=code