### PR TITLE
Allow parsing of Boolean[false] as a valid Boolean definition

### DIFF
--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.7'
 
   spec.add_development_dependency 'bundler', '>= 1.3', '< 3'
-  spec.add_development_dependency 'minitest'
+  spec.add_development_dependency 'minitest', '< 6'
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'simplecov'

--- a/lib/kafo/data_types/boolean.rb
+++ b/lib/kafo/data_types/boolean.rb
@@ -1,6 +1,10 @@
 module Kafo
   module DataTypes
     class Boolean < DataType
+      def initialize(*permitted)
+        @permitted = permitted
+      end
+
       def typecast(value)
         case value
           when '0', 'false', 'f', 'n', false
@@ -16,6 +20,12 @@ module Kafo
         (input.is_a?(::TrueClass) || input.is_a?(::FalseClass)).tap do |valid|
           errors << "#{input.inspect} is not a valid boolean" unless valid
         end
+
+        unless @permitted.empty? || @permitted.include?(input)
+          errors << "#{input} must be one of #{@permitted.join(', ')}"
+        end
+
+        return errors.empty?
       end
     end
 

--- a/lib/kafo/data_types/struct.rb
+++ b/lib/kafo/data_types/struct.rb
@@ -5,10 +5,12 @@ module Kafo
         @spec = ::Hash[spec.map do |k,v|
           begin
             k = DataType.new_from_string(k)
-          rescue ConfigurationException; end
+          rescue ConfigurationException
+          end
           begin
             v = DataType.new_from_string(v)
-          rescue ConfigurationException; end
+          rescue ConfigurationException
+          end
           [k, v]
         end]
       end

--- a/test/kafo/data_types/boolean_test.rb
+++ b/test/kafo/data_types/boolean_test.rb
@@ -5,6 +5,7 @@ module Kafo
     describe Boolean do
       describe "registered" do
         it { _(DataType.new_from_string('Boolean')).must_be_instance_of Boolean }
+        it { _(DataType.new_from_string('Boolean[false]')).must_be_instance_of Boolean }
       end
 
       describe "#typecast" do
@@ -21,6 +22,8 @@ module Kafo
         it { _(Boolean.new.valid?(true)).must_equal true }
         it { _(Boolean.new.valid?(false)).must_equal true }
         it { _(Boolean.new.valid?('foo')).must_equal false }
+        it { _(Boolean.new(false).valid?(true)).must_equal false }
+        it { _(Boolean.new(false).valid?(false)).must_equal true }
       end
     end
   end


### PR DESCRIPTION
https://github.com/theforeman/puppet-puppet/commit/c87087a9abf631a67aa14a2107c8e25fdbf74c40 introduced this notation, and it seems to be valid for Puppet