### PR TITLE
Allow highline 3.x

### DIFF
--- a/kafo.gemspec
+++ b/kafo.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   # CLI interface
   spec.add_dependency 'clamp', '>= 1.3.1', '< 2'
   # interactive mode
-  spec.add_dependency 'highline', '>= 1.6.21', '< 3.0'
+  spec.add_dependency 'highline', '>= 1.6.21', '< 4.0'
   # ruby progress bar
   spec.add_dependency 'powerbar'
 end


### PR DESCRIPTION
## Summary

Relaxes the `highline` dependency upper bound from `< 3.0` to `< 4.0` so kafo can pick up highline 3.x.

This is currently blocking foreman-packaging: a highline 2.1.0 -> 3.1.2 bump broke repoclosure for the whole `foreman` nightly staging group because kafo pins `highline < 3.0` and only 3.1.2 is now published (theforeman/foreman-packaging#13715).

## Compatibility

highline 3.0 reworked its internals but the public surface kafo uses is unchanged: `HighLine.new`, `agree`/`ask`/`choose`/`say`, `HighLine::String`, `terminal`/`terminal_size`.

Verified by relaxing the gemspec pin locally and running the full unit test suite against highline 3.1.2:

```
769 tests, 1056 assertions, 0 failures, 0 errors, 0 skips
```

## Open question for maintainers

Should the upper bound be dropped entirely instead of bumped to `< 4.0`? Happy to update the PR either way, wanted to leave that call to you rather than assume it.

## Test plan

- [x] `bundle exec rake test:unit` passes against highline 3.1.2 (769/769)